### PR TITLE
fix `fotmob_get_league_matches` error message

### DIFF
--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -51,7 +51,7 @@
   n_league_urls <- nrow(league_urls)
   if(n_league_urls == 0) {
     stop(
-      'Could not find any leagues matching specified parameters.',
+      'Could not find any leagues matching specified parameters.'
     )
   }
 

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -59,7 +59,15 @@ test_that("fotmob_get_league_matches() works", {
   # must also provide country
   expect_error(
     fotmob_get_league_matches(
-      country = "Premier League"
+      league_name = "Premier League"
+    )
+  )
+
+  # mis-specified league_name
+  expect_error(
+    fotmob_get_league_matches(
+      country = "ESP",
+      league_name = "La Liga"
     )
   )
 


### PR DESCRIPTION
The error message was not being correctly printed out when all of the countries/league_names are mis-specified in `fotmob_get_league_matches`.