### PR TITLE
Fix team ids in non-domestic matches for `fotmob_get_match_players()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Functions to Extract and Clean World Football (Soccer) Data
-Version: 0.5.1.4000
+Version: 0.5.1.5000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# worldfootballR 0.5.1.5000
+
+### Bugs
+
+* `fotmob_get_match_players` failed for non-domestic leagues because the `team` element does id not exist under the `table` element. Fix is to have more robust element for assigning team ids for players.
+
 # worldfootballR 0.5.1.4000
 
 

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -205,8 +205,20 @@ fotmob_get_match_players <- function(match_ids) {
       tibble::as_tibble()
     ## Overwrite the existing variables since the away team value is "bad".
     ##   See https://github.com/JaseZiv/worldfootballR/issues/93
-    res$home_team_id <- table$teams[1]
-    res$away_team_id <- table$teams[2]
+    ## For non-domestic leagues, the table element will not have a teams element
+    ##   See https://github.com/JaseZiv/worldfootballR/issues/111
+    coerce_team_id <- function(df, side) {
+      idx <- ifelse(side == "home", 1, 2)
+      team_col <- sprintf("%s_team_id", side)
+      df[[team_col]] <- ifelse(
+        is.logical(table) | !("teams" %in% names(table)),
+        df[[team_col]],
+        table$teams[idx]
+      )
+      df
+    }
+    res <- coerce_team_id(res, "home")
+    res <- coerce_team_id(res, "away")
     res
   }
 

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -275,5 +275,10 @@ test_that("fotmob_get_match_players() works", {
   players <- fotmob_get_match_players(c(3609987, 3609979))
   expect_gt(nrow(players), 0)
   expect_equal(ncol(players), 32)
+
+  ## non-domestic league
+  players <- fotmob_get_match_players(3846347)
+  expect_gt(nrow(players), 0)
+  expect_equal(ncol(players), 32)
 })
 


### PR DESCRIPTION
Previously I was testing on domestic league matches and didn't realize that the `table` element in the JSON response for a non-domestic match would be just `FALSE` instead of an array of size 2 with the team ids. We are using the `table` element to "correct" for "bad" away team ids (see #93). In the case that the match is non-domestic, we resort to leaving the `away_team_id` as is.

fixes #111