### PR TITLE
Various fotmob fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Functions to Extract and Clean World Football (Soccer) Data
-Version: 0.5.2.2000
+Version: 0.5.2.3000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# worldfootballR 0.5.2.3000
+
+### Bugs
+
+* `fotmob_get_leage_matches()` and `fotmob_get_league_tables()` after changes to names in JSON response (`fixtures` -> `matches`, `tableData` -> `table`) [#121](https://github.com/JaseZiv/worldfootballR/issues/121), [#122](https://github.com/JaseZiv/worldfootballR/issues/122)
+* Various fotmob functions affected by addition of `api/` in URL
+* New names to player stats outdated docs for `fotmob_get_season_stats()`
+
 # worldfootballR 0.5.2.2000
 
 ### Bugs

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -142,7 +142,7 @@ fotmob_get_league_ids <- function(cached = TRUE) {
 }
 
 .fotmob_get_league_resp <- function(league_id, page_url) {
-  url <- sprintf("https://www.fotmob.com/leagues?id=%s", league_id)
+  url <- sprintf("https://www.fotmob.com/api/leagues?id=%s", league_id)
   res <- .safely_from_json(url)
   if(!is.null(res$result)) {
     return(res$result)
@@ -234,12 +234,12 @@ fotmob_get_league_matches <- function(country, league_name, league_id, cached = 
 #' @importFrom tibble as_tibble
 .fotmob_get_league_matches <- function(league_id, page_url) {
   resp <- .fotmob_get_league_resp(league_id, page_url)
-  f <- if("fixtures" %in% names(resp)) {
+  f <- if("matches" %in% names(resp)) {
     I
   } else {
     .fotmob_extract_data_from_page_props
   }
-  f(resp)$fixtures %>%
+  f(resp)$matches %>%
     janitor::clean_names() %>%
     tibble::as_tibble()
 }
@@ -311,12 +311,12 @@ fotmob_get_league_tables <- function(country, league_name, league_id, cached = T
 #' @importFrom tidyr pivot_longer unnest_longer unnest
 .fotmob_get_league_tables <- function(league_id, page_url) {
   resp <- .fotmob_get_league_resp(league_id, page_url)
-  f <- if("tableData" %in% names(resp)) {
+  f <- if("table" %in% names(resp)) {
     I
   } else {
     .fotmob_extract_data_from_page_props
   }
-  table_init <- f(resp)$tableData
+  table_init <- f(resp)$table
   cols <- c("all", "home", "away")
   table <- if("table" %in% names(table_init)) {
     table_init$table %>% dplyr::select(dplyr::all_of(cols))

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -37,7 +37,7 @@ fotmob_get_matches_by_date <- function(dates) {
   # CRAN feedback was to remove this from the existing functions so I have for now
   # print(glue::glue('Scraping match results data from fotmob for "{date}".'))
 
-  main_url <- "https://www.fotmob.com/"
+  main_url <- "https://www.fotmob.com/api/"
 
   is_date <- lubridate::is.Date(date)
   if(is_date) {
@@ -91,7 +91,7 @@ fotmob_get_match_details <- function(match_ids) {
 .fotmob_get_single_match_details <- function(match_id) {
   # CRAN feedback was to remove this from the existing functions so I have for now
   # print(glue::glue("Scraping match data from fotmob for match {match_id}."))
-  main_url <- "https://www.fotmob.com/"
+  main_url <- "https://www.fotmob.com/api/"
   url <- paste0(main_url, "matchDetails?matchId=", match_id)
 
   f <- function(url) {

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -54,7 +54,7 @@ fotmob_get_match_players <- function(match_ids) {
 .fotmob_get_single_match_players <- function(match_id) {
   # CRAN feedback was to remove this from the existing functions so I have for now
   # print(glue::glue("Scraping match data from fotmob for match {match_id}."))
-  main_url <- "https://www.fotmob.com/"
+  main_url <- "https://www.fotmob.com/api/"
   url <- paste0(main_url, "matchDetails?matchId=", match_id)
 
   f <- function(url) {

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -90,41 +90,68 @@
 #'
 #' @param team_or_player return statistics for either \code{"team"} or \code{"player"}. Can only be one or the other.
 #' @param stat_name the type of statistic. Can be more than one.
-#' `stat_name` may be one of the following, although it may not be available for both \code{"team"} or \code{"player"}:
+#' `stat_name` must be one of the following for \code{"player"}:
+#' \item{Accurate long balls per 90}
+#' \item{Accurate passes per 90}
+#' \item{Assists}
+#' \item{Big chances created}
+#' \item{Big chances missed}
+#' \item{Blocks per 90}
+#' \item{Chances created}
+#' \item{Clean sheets}
+#' \item{Clearances per 90}
+#' \item{Expected assist (xA)}
+#' \item{Expected assist (xA) per 90}
+#' \item{Expected goals (xG)}
+#' \item{Expected goals (xG) per 90}
+#' \item{Expected goals on target (xGOT)}
+#' \item{FotMob rating}
+#' \item{Fouls committed per 90}
+#' \item{Goals + Assists}
+#' \item{Goals conceded per 90}
+#' \item{Goals per 90}
+#' \item{Goals prevented}
+#' \item{Interceptions per 90}
+#' \item{Penalties conceded}
+#' \item{Penalties won}
+#' \item{Possession won final 3rd per 90}
+#' \item{Red cards}
+#' \item{Save percentage}
+#' \item{Saves per 90}
+#' \item{Shots on target per 90}
+#' \item{Shots per 90}
+#' \item{Successful dribbles per 90}
+#' \item{Successful tackles per 90}
+#' \item{Top scorer}
+#' \item{xG + xA per 90}
+#' \item{Yellow cards}
+#' }
+#' 
+#' For \code{"team"}, `stat_name` must be one of the following:
 #' \itemize{
-#' \item{"Accurate long balls per 90"}
-#' \item{"Accurate passes per 90"}
-#' \item{"Assists}
-#' \item{"Big chances created"}
-#' \item{"Big chances missed"}
-#' \item{"Blocks per 90"}
-#' \item{"Chances created}
-#' \item{"Clean sheets"}
-#' \item{"Clearances per 90"}
-#' \item{"Expected assist (xA)"}
-#' \item{"Expected assist (xA) per 90"}
-#' \item{"Expected goals (xG)"}
-#' \item{"Expected goals (xG) per 90"}
-#' \item{"Expected goals on target (xGOT)"}
-#' \item{"FotMob rating"}
-#' \item{"Fouls committed per 90"}
-#' \item{"Goals + Assists"}
-#' \item{"Goals conceded per 90"}
-#' \item{"Goals per 90"}
-#' \item{"Goals prevented"}
-#' \item{"Interceptions per 90"}
-#' \item{"Penalties conceded"}
-#' \item{"Penalties won"}
-#' \item{"Possession won final 3rd per 90"}
-#' \item{"Red cards"}
-#' \item{"Saves per 90"}
-#' \item{"Shots on target per 90"}
-#' \item{"Shots per 90"}
-#' \item{"Successful dribbles per 90"}
-#' \item{"Successful tackles per 90"}
-#' \item{"Top scorer"}
-#' \item{"xG + xA per 90"}
-#' \item{"Yellow cards"}
+#' \item{Accurate crosses per match}
+#' \item{Accurate long balls per match}
+#' \item{Accurate passes per match}
+#' \item{Average possession}
+#' \item{Big chances created}
+#' \item{Big chances missed}
+#' \item{Clean sheets}
+#' \item{Clearances per match}
+#' \item{Expected goals}
+#' \item{FotMob rating}
+#' \item{Fouls per match}
+#' \item{Goals conceded per match}
+#' \item{Goals per match}
+#' \item{Interceptions per match}
+#' \item{Penalties awarded}
+#' \item{Penalties conceded}
+#' \item{Possession won final 3rd per match}
+#' \item{Red cards}
+#' \item{Saves per match}
+#' \item{Shots on target per match}
+#' \item{Successful tackles per match}
+#' \item{xG conceded}
+#' \item{Yellow cards}
 #' }
 #'
 #' Fotmob has changed these stat names over time, so this list may be out-dated. If you try an invalid stat name, you should see an error message indicating which ones are available.

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -1,11 +1,4 @@
 
-#' @importFrom dplyr filter
-.fotmob_validate_stat_type <- function(stat_name) {
-
-
-  res
-}
-
 #' @importFrom jsonlite fromJSON
 #' @importFrom tibble tibble as_tibble
 #' @importFrom dplyr select
@@ -57,6 +50,7 @@
     league_name = rlang::maybe_missing(league_name, NULL),
     league_id = rlang::maybe_missing(league_id, NULL)
   )
+
   url <- sprintf(
     "https://www.fotmob.com%s/%ss",
     stringr::str_replace(tables$page_url[1], "overview", "stats"),
@@ -98,31 +92,42 @@
 #' @param stat_name the type of statistic. Can be more than one.
 #' `stat_name` may be one of the following, although it may not be available for both \code{"team"} or \code{"player"}:
 #' \itemize{
-#' \item{"Accurate passes per match"}
-#' \item{"Average possession"}
+#' \item{"Accurate long balls per 90"}
+#' \item{"Accurate passes per 90"}
 #' \item{"Assists}
 #' \item{"Big chances created"}
 #' \item{"Big chances missed"}
+#' \item{"Blocks per 90"}
+#' \item{"Chances created}
 #' \item{"Clean sheets"}
-#' \item{"Clearances per match"}
-#' \item{"Expected Goals"}
-#' \item{"Expected Goals conceded"}
+#' \item{"Clearances per 90"}
+#' \item{"Expected assist (xA)"}
+#' \item{"Expected assist (xA) per 90"}
+#' \item{"Expected goals (xG)"}
+#' \item{"Expected goals (xG) per 90"}
+#' \item{"Expected goals on target (xGOT)"}
 #' \item{"FotMob rating"}
-#' \item{"Goals"}
-#' \item{"Goals conceded per match"}
-#' \item{"Goals per match"}
-#' \item{"Key passes per match"}
-#' \item{"Minutes per goal"}
-#' \item{"Penalties awarded"}
+#' \item{"Fouls committed per 90"}
+#' \item{"Goals + Assists"}
+#' \item{"Goals conceded per 90"}
+#' \item{"Goals per 90"}
+#' \item{"Goals prevented"}
+#' \item{"Interceptions per 90"}
 #' \item{"Penalties conceded"}
-#' \item{"Possession won final 3rd"}
+#' \item{"Penalties won"}
+#' \item{"Possession won final 3rd per 90"}
 #' \item{"Red cards"}
-#' \item{"Saves per match"}
-#' \item{"Shots on target per match"}
-#' \item{"Successful dribbles per match"}
-#' \item{"Successful tackles per match"}
+#' \item{"Saves per 90"}
+#' \item{"Shots on target per 90"}
+#' \item{"Shots per 90"}
+#' \item{"Successful dribbles per 90"}
+#' \item{"Successful tackles per 90"}
+#' \item{"Top scorer"}
+#' \item{"xG + xA per 90"}
 #' \item{"Yellow cards"}
 #' }
+#'
+#' Fotmob has changed these stat names over time, so this list may be out-dated. If you try an invalid stat name, you should see an error message indicating which ones are available.
 #'
 #' @return returns a dataframe of team or player stats
 #'
@@ -139,7 +144,7 @@
 #'   country = "ENG",
 #'   league_name = "Premier League",
 #'   season = "2020/2021",
-#'   stat_type = "xg",
+#'   stat_type = "Expected goals",
 #'   team_or_player = "team"
 #' )
 #'
@@ -149,11 +154,12 @@
 #'   season = "2016/2017"
 #' )
 #'
+#' ## Note that the `stat_type` name is slightly different.
 #' epl_player_xg_2021 <- get_epl_season_stats(
 #'   country = "ENG",
 #'   league_name = "Premier League",
 #'   season = "2020/2021",
-#'   stat_type = "xg",
+#'   stat_type = "Expected goals (xG)",
 #'   team_or_player = "player"
 #' )
 #' }

--- a/man/fotmob_get_season_stats.Rd
+++ b/man/fotmob_get_season_stats.Rd
@@ -27,7 +27,7 @@ fotmob_get_season_stats(
 \item{team_or_player}{return statistics for either \code{"team"} or \code{"player"}. Can only be one or the other.}
 
 \item{stat_name}{the type of statistic. Can be more than one.
-`stat_name` may be one of the following, although it may not be available for both \code{"team"} or \code{"player"}:
+\code{stat_name} must be one of the following for \code{"player"}:
 \itemize{
 \item{"Accurate long balls per 90"}
 \item{"Accurate passes per 90"}
@@ -62,6 +62,33 @@ fotmob_get_season_stats(
 \item{"Top scorer"}
 \item{"xG + xA per 90"}
 \item{"Yellow cards"}
+}
+
+For `"team"`, `stat_name` must be one of the following:
+\itemize{
+\item{Accurate crosses per match}
+\item{Accurate long balls per match}
+\item{Accurate passes per match}
+\item{Average possession}
+\item{Big chances created}
+\item{Big chances missed}
+\item{Clean sheets}
+\item{Clearances per match}
+\item{Expected goals}
+\item{FotMob rating}
+\item{Fouls per match}
+\item{Goals conceded per match}
+\item{Goals per match}
+\item{Interceptions per match}
+\item{Penalties awarded}
+\item{Penalties conceded}
+\item{Possession won final 3rd per match}
+\item{Red cards}
+\item{Saves per match}
+\item{Shots on target per match}
+\item{Successful tackles per match}
+\item{xG conceded}
+\item{Yellow cards}
 }
 
 Fotmob has changed these stat names over time, so this list may be out-dated. If you try an invalid stat name, you should see an error message indicating which ones are available.}

--- a/man/fotmob_get_season_stats.Rd
+++ b/man/fotmob_get_season_stats.Rd
@@ -29,31 +29,42 @@ fotmob_get_season_stats(
 \item{stat_name}{the type of statistic. Can be more than one.
 `stat_name` may be one of the following, although it may not be available for both \code{"team"} or \code{"player"}:
 \itemize{
-\item{"Accurate passes per match"}
-\item{"Average possession"}
+\item{"Accurate long balls per 90"}
+\item{"Accurate passes per 90"}
 \item{"Assists}
 \item{"Big chances created"}
 \item{"Big chances missed"}
+\item{"Blocks per 90"}
+\item{"Chances created}
 \item{"Clean sheets"}
-\item{"Clearances per match"}
-\item{"Expected Goals"}
-\item{"Expected Goals conceded"}
+\item{"Clearances per 90"}
+\item{"Expected assist (xA)"}
+\item{"Expected assist (xA) per 90"}
+\item{"Expected goals (xG)"}
+\item{"Expected goals (xG) per 90"}
+\item{"Expected goals on target (xGOT)"}
 \item{"FotMob rating"}
-\item{"Goals"}
-\item{"Goals conceded per match"}
-\item{"Goals per match"}
-\item{"Key passes per match"}
-\item{"Minutes per goal"}
-\item{"Penalties awarded"}
+\item{"Fouls committed per 90"}
+\item{"Goals + Assists"}
+\item{"Goals conceded per 90"}
+\item{"Goals per 90"}
+\item{"Goals prevented"}
+\item{"Interceptions per 90"}
 \item{"Penalties conceded"}
-\item{"Possession won final 3rd"}
+\item{"Penalties won"}
+\item{"Possession won final 3rd per 90"}
 \item{"Red cards"}
-\item{"Saves per match"}
-\item{"Shots on target per match"}
-\item{"Successful dribbles per match"}
-\item{"Successful tackles per match"}
+\item{"Saves per 90"}
+\item{"Shots on target per 90"}
+\item{"Shots per 90"}
+\item{"Successful dribbles per 90"}
+\item{"Successful tackles per 90"}
+\item{"Top scorer"}
+\item{"xG + xA per 90"}
 \item{"Yellow cards"}
-}}
+}
+
+Fotmob has changed these stat names over time, so this list may be out-dated. If you try an invalid stat name, you should see an error message indicating which ones are available.}
 
 \item{stat_league_name}{Same format as `league_name`. If not provided explicitly, then it takes on the same value as `league_name`. If provided explicitly, should be of the same length as `league_name` (or `league_id` if `league_name` is not provided).
 
@@ -73,7 +84,7 @@ epl_team_xg_2021 <- fotmob_get_season_stats(
   country = "ENG",
   league_name = "Premier League",
   season = "2020/2021",
-  stat_type = "xg",
+  stat_type = "Expected goals",
   team_or_player = "team"
 )
 
@@ -83,11 +94,12 @@ get_epl_season_stats(
   season = "2016/2017"
 )
 
+## Note that the `stat_type` name is slightly different.
 epl_player_xg_2021 <- get_epl_season_stats(
   country = "ENG",
   league_name = "Premier League",
   season = "2020/2021",
-  stat_type = "xg",
+  stat_type = "Expected goals (xG)",
   team_or_player = "player"
 )
 }

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -2,7 +2,7 @@ context("Testing fotmob functions")
 
 
 test_that("fotmob_get_matches_by_date() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   results <- fotmob_get_matches_by_date(date = c("20210925", "20210926"))
   expect_gt(nrow(results), 0)
@@ -10,7 +10,7 @@ test_that("fotmob_get_matches_by_date() works", {
 })
 
 test_that("fotmob_get_league_matches() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   league_matches <- fotmob_get_league_matches(
     country = "ENG",
@@ -100,7 +100,7 @@ test_that("fotmob_get_league_matches() works", {
 
 
 test_that("fotmob_get_league_tables() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   n_expected_domestic_league_table_cols <- 16
   epl_league_table <- fotmob_get_league_tables(
@@ -149,7 +149,7 @@ test_that("fotmob_get_league_tables() works", {
 })
 
 test_that("fotmob_get_season_stats() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   n_expected_stat_cols <- 20
   epl_team_xg_21_a <- fotmob_get_season_stats(
@@ -291,7 +291,7 @@ test_that("fotmob_get_season_stats() works", {
 })
 
 test_that("fotmob_get_match_details() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   n_expected_match_detail_cols <- 15
   details <- fotmob_get_match_details(c(3609987, 3609979))
@@ -308,7 +308,7 @@ test_that("fotmob_get_match_details() works", {
 
 
 test_that("fotmob_get_match_players() works", {
-  # testthat::skip_on_cran()
+  testthat::skip_on_cran()
 
   n_expected_match_player_cols <- 32
   players <- fotmob_get_match_players(c(3609987, 3609979))

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -2,7 +2,7 @@ context("Testing fotmob functions")
 
 
 test_that("fotmob_get_matches_by_date() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   results <- fotmob_get_matches_by_date(date = c("20210925", "20210926"))
   expect_gt(nrow(results), 0)
@@ -10,7 +10,7 @@ test_that("fotmob_get_matches_by_date() works", {
 })
 
 test_that("fotmob_get_league_matches() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   league_matches <- fotmob_get_league_matches(
     country = "ENG",
@@ -100,7 +100,7 @@ test_that("fotmob_get_league_matches() works", {
 
 
 test_that("fotmob_get_league_tables() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   n_expected_domestic_league_table_cols <- 16
   epl_league_table <- fotmob_get_league_tables(
@@ -149,7 +149,7 @@ test_that("fotmob_get_league_tables() works", {
 })
 
 test_that("fotmob_get_season_stats() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   n_expected_stat_cols <- 20
   epl_team_xg_21_a <- fotmob_get_season_stats(
@@ -164,7 +164,7 @@ test_that("fotmob_get_season_stats() works", {
   get_epl_season_stats <- function(
     season_name = "2020/2021",
     team_or_player = "team",
-    stat_name = "Expected goals"
+    stat_name = ifelse(team_or_player == "team", "Expected goals", "Expected goals (xG)")
   ) {
     fotmob_get_season_stats(
       country = "ENG",
@@ -291,7 +291,7 @@ test_that("fotmob_get_season_stats() works", {
 })
 
 test_that("fotmob_get_match_details() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   n_expected_match_detail_cols <- 15
   details <- fotmob_get_match_details(c(3609987, 3609979))
@@ -308,7 +308,7 @@ test_that("fotmob_get_match_details() works", {
 
 
 test_that("fotmob_get_match_players() works", {
-  testthat::skip_on_cran()
+  # testthat::skip_on_cran()
 
   n_expected_match_player_cols <- 32
   players <- fotmob_get_match_players(c(3609987, 3609979))

--- a/vignettes/extract-fotmob-data.Rmd
+++ b/vignettes/extract-fotmob-data.Rmd
@@ -75,34 +75,7 @@ fotmob has data for just about every league that you can think of, including all
 
 ### Team Stats
 
-Use `fotmob_get_season_stats` to retrieve values for a specified stat, season, and league. Currently the available stat types are as follows:
-
--   "Accurate passes per match"
--   "Average possession"
--   "Assists
--   "Big chances created"
--   "Big chances missed"
--   "Clean sheets"
--   "Clearances per match"
--   "Expected goals"
--   "xG conceded"
--   "FotMob rating"
--   "Goals"
--   "Goals conceded per match"
--   "Goals per match"
--   "Key passes per match"
--   "Minutes per goal"
--   "Penalties awarded"
--   "Penalties conceded"
--   "Possession won final 3rd"
--   "Red cards"
--   "Saves per match"
--   "Shots on target per match"
--   "Successful dribbles per match"
--   "Successful tackles per match"
--   "Yellow cards"
-
-Note that some of these are only available for either team or player.
+Use `fotmob_get_season_stats` to retrieve values for a specified stat, season, and league. See the docs for the function for a complete list of `stat_name`s. Note that some stats are only available for either team or player, and that some names are different for teams and players (e.g. `"Expected goals"` for `"team"` and `"Expected goals (xG)"` for `"player"`).
 
 ```{r epl_team_xg_2021}
 epl_team_xg_2021 <- fotmob_get_season_stats(
@@ -189,7 +162,7 @@ epl_player_xg_2021 <- fotmob_get_season_stats(
   country = "ENG",
   league_name = "Premier League",
   season = "2020/2021",
-  stat_name = "Expected goals",
+  stat_name = "Expected goals (xG)",
   team_or_player = "player"
 )
 


### PR DESCRIPTION
Fixes #121 and #122.

* `fotmob_get_leage_matches()` and `fotmob_get_league_tables()` after changes to names in JSON response (`fixtures` -> `matches`, `tableData` -> `table`) [#121](https://github.com/JaseZiv/worldfootballR/issues/121), [#122](https://github.com/JaseZiv/worldfootballR/issues/122)
* Various fotmob functions affected by addition of `api/` in URL
* New names to player stats outdated docs for `fotmob_get_season_stats()`


Evidence for tests passing locally:
![image](https://user-images.githubusercontent.com/15663460/169717227-75193ae6-b127-4be0-8d4c-90f0bc2b991a.png)
