### PR TITLE
Fix `fotmob_get_season_stats`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.5.8.1000
+Version: 0.5.8.2000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,8 @@
-# worldfootballR 0.5.8.1000
+# worldfootballR 0.5.8.2000
 
 ### Bug fixes
 
-* `get_match_lineups()` wasn't returning the away team name [#147](https://github.com/JaseZiv/worldfootballR/issues/147)
-* `understat_league_season_shots()` would error when passing in a new `season_start_year` value for seasons that haven't yet started but match fixtures are available on Understat [#148](https://github.com/JaseZiv/worldfootballR/issues/148)
-
+* `fotmob_get_season_stats()`: Address logic for extracting season ids from season stats pages that was failing due to blank stats pages in the offseason for a league.
 # worldfootballR 0.5.8
 
 ### Improvements


### PR DESCRIPTION
Addresses logic for extracting season ids from season stats pages in  `fotmob_get_season_stats()`. This was failing due to blank stats pages in the off-season for a league.

Tests passed locally
![image](https://user-images.githubusercontent.com/15663460/181854696-24a72225-9be1-4d0c-b6a2-d9599e8390dd.png)
