### PR TITLE
Return stats at characters in `fotmob_get_match_players()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.5.8.2000
+Version: 0.5.9
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,21 @@
-# worldfootballR 0.5.8.2000
+# worldfootballR 0.5.9
 
 ### Bug fixes
 
+* `fotmob_get_match_players()` returns stats as characters [#150](https://github.com/JaseZiv/worldfootballR/issues/150)
+
+# worldfootballR 0.5.8.2000
+### Bug fixes
+
 * `fotmob_get_season_stats()`: Address logic for extracting season ids from season stats pages that was failing due to blank stats pages in the offseason for a league.
+
+# worldfootballR 0.5.8.1000
+
+### Bug fixes
+
+* `get_match_lineups()` wasn't returning the away team name [#147](https://github.com/JaseZiv/worldfootballR/issues/147)
+* `understat_league_season_shots()` would error when passing in a new `season_start_year` value for seasons that haven't yet started but match fixtures are available on Understat [#148](https://github.com/JaseZiv/worldfootballR/issues/148)
+
 # worldfootballR 0.5.8
 
 ### Improvements

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -54,6 +54,7 @@ fotmob_get_match_players <- function(match_ids) {
 #' @importFrom rlang .data
 #' @importFrom janitor make_clean_names
 #' @importFrom tibble as_tibble tibble
+#' @importFrom stringr str_detect
 .fotmob_get_single_match_players <- function(match_id) {
   # CRAN feedback was to remove this from the existing functions so I have for now
   # print(glue::glue("Scraping match data from fotmob for match {match_id}."))
@@ -87,7 +88,7 @@ fotmob_get_match_players <- function(match_ids) {
         rn <- rownames(xt)
         suppressWarnings(
           xt2 <- matrix(
-            as.numeric(gsub("%", "", xt)),
+            as.character(xt),
             ncol = ncol(xt)
           ) %>%
             tibble::as_tibble()
@@ -102,7 +103,7 @@ fotmob_get_match_players <- function(match_ids) {
           dplyr::select(
             -.data$name
           ) %>%
-          dplyr::filter(!is.na(.data$value)) %>%
+          dplyr::filter(stringr::str_detect(.data$col, "^stats_"), !is.na(.data$value)) %>%
           dplyr::distinct(.data$col, .data$value) %>%
           tidyr::pivot_wider(
             names_from = "col",

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -343,7 +343,7 @@ test_that("fotmob_get_match_details() works", {
 test_that("fotmob_get_match_players() works", {
   testthat::skip_on_cran()
 
-  n_expected_match_player_cols <- 69
+  n_expected_match_player_cols <- 73
   players <- fotmob_get_match_players(c(3609987, 3609979))
   expect_gt(nrow(players), 0)
   expect_equal(ncol(players), n_expected_match_player_cols)


### PR DESCRIPTION
Fixes #150.

fotmob now returns the successful count, total, and percentage for percentage stats (e.g. Accuracy %). I think we should be "lazy", forcing every stat column to be a character. The onus is shifted to the user to coerce what they want to numerics.

For example, for accuracy %, the raw number of successful passes may be more interesting to the user than the accuracy %, so we leave the value as is (e.g. `4/5 (80%)`) and let the user extract what they want. Yes, this makes it inconvenient for a stat like goals, which is just reported as a count, forcing the user to always coerce goals to numeric from a character, but I think this design is ok. 

fotmob has changed their API a lot, and I think we want to reduce maintenance demand on our end. If we're returning characters for all stats, the likelihood of us needing to change existing code is reduced. Additionally, I'm guessing that users are typically interested in only a handful of stats and not all of them. Asking users to coerce 2 or 3 stats doesn't seem like too big of an ask to me.