### PR TITLE
Fix `fotmob_get_league_tables`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.5.9
+Version: 0.5.9.9000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# worldfootballR 0.5.9.9000
+
+### Improvements
+
+* Improve fotmob tests by checking for column names instead of just number of columns.
+### Bug fixes
+
+* `fotmob_get_league_tables()`: Fix unnesting to accomodate additional nesting and identical names at different levels. This bug affected `fotmob_get_season_stats()`, which calls `fotmob_get_league_tables()` [#155](https://github.com/JaseZiv/worldfootballR/issues/155)
+
 # worldfootballR 0.5.9
 
 ### Bug fixes

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -330,7 +330,7 @@ fotmob_get_league_tables <- function(country, league_name, league_id, cached = T
   } else {
     .fotmob_extract_data_from_page_props
   }
-  table_init <- f(resp)$table
+  table_init <- f(resp)$table$data
   cols <- c("all", "home", "away")
   table <- if("table" %in% names(table_init)) {
     table_init$table %>% dplyr::select(dplyr::all_of(cols))
@@ -367,13 +367,11 @@ fotmob_get_league_tables <- function(country, league_name, league_id, cached = T
       .data$table
     ) %>%
     tidyr::unnest(
-      .data$table
+      .data$table,
+      names_sep = "_"
     ) %>%
     janitor::clean_names() %>%
-    tibble::as_tibble() %>%
-    dplyr::rename(
-      team_page_url = .data$page_url
-    )
+    tibble::as_tibble()
 
   res %>%
     dplyr::mutate(


### PR DESCRIPTION
Apparently there was an additional level of nesting introduced recently. Also, for a league like MLS, I found that `unnest`ing was broken due to `page_url` existing at multiple levels, causing an identical name conflict when unnesting. This is resolved by specifying `names_sep = "_"`, which introduces a prefix for names unnested.