### PR TITLE
Fix `fotmob_get_matches_by_date()` for future match dates.

### DIFF
--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -92,7 +92,6 @@ fotmob_get_matches_by_date <- function(dates) {
       tidyr::unnest(.data[["match"]], names_sep = "_") %>%
       dplyr::rename(home = .data[["match_home"]], away = .data[["match_away"]]) %>%
       tidyr::unnest(c(.data[["home"]], .data[["away"]], .data[["match_status"]]), names_sep = "_") %>%
-      tidyr::unnest(c(.data[["match_status_reason"]])) %>%
       dplyr::select(-tidyselect::vars_select_helpers$where(is.list)) %>%
       janitor::clean_names()
   }


### PR DESCRIPTION
There was an issue with calling `fotmob_get_matches_by_date()` for future dates. fotmob doesn't return the `match_status_reason column` for such matches. The issue is resolved by dropping `match_status_reason`, which is typically a nested data frame that has redundant information with the other `match_status_ columns`, e.g. `match_status_finished`. The prior code was arguably brittle anyways.

```r
future <- c("20221017","20221025","20221027","20221028","20221031","20221101")
results <- fotmob_get_matches_by_date(dates = future)
str(results)
```

```
tibble [526 × 34] (S3: tbl_df/tbl/data.frame)
 $ ccode                            : chr [1:526] "USA" "USA" "ESP" "ITA" ...
 $ id                               : int [1:526] 881538 881538 87 55 55 879435 879435 879435 879435 879435 ...
 $ primary_id                       : int [1:526] 130 130 87 55 55 112 112 112 112 112 ...
 $ name                             : chr [1:526] "Major League Soccer Playoff" "Major League Soccer Playoff" "LaLiga" "Serie A" ...
 $ match_id                         : int [1:526] 4044411 4044412 3918026 3919186 3919184 3885772 3885766 3885769 3885780 3885767 ...
 $ match_league_id                  : int [1:526] 881538 881538 87 55 55 879435 879435 879435 879435 879435 ...
 $ match_time                       : chr [1:526] "18.10.2022 01:00" "18.10.2022 03:30" "17.10.2022 21:00" "17.10.2022 18:30" ...
 $ home_id                          : int [1:526] 546238 6399 10205 9882 9888 10098 10079 202757 161727 10103 ...
 $ home_score                       : int [1:526] 0 0 0 0 0 0 0 0 0 0 ...
 $ home_name                        : chr [1:526] "NYCFC" "Dallas" "Villarreal" "Sampdoria" ...
 $ home_long_name                   : chr [1:526] "New York City FC" "FC Dallas" "Villarreal" "Sampdoria" ...
 $ away_id                          : int [1:526] 960720 207242 8371 8686 8535 213534 10094 10083 10096 10086 ...
 $ away_score                       : int [1:526] 0 0 0 0 0 0 0 0 0 0 ...
 $ away_name                        : chr [1:526] "Inter Miami CF" "Minnesota" "Osasuna" "Roma" ...
 $ away_long_name                   : chr [1:526] "Inter Miami CF" "Minnesota United" "Osasuna" "Roma" ...
 $ match_eliminated_team_id         : logi [1:526] NA NA NA NA NA NA ...
 $ match_status_id                  : int [1:526] 1 1 1 1 1 1 1 1 1 1 ...
 $ match_tournament_stage           : chr [1:526] "1/8" "1/8" "9" "10" ...
 $ match_status_started             : logi [1:526] FALSE FALSE FALSE FALSE FALSE FALSE ...
 $ match_status_cancelled           : logi [1:526] FALSE FALSE FALSE FALSE FALSE FALSE ...
 $ match_status_finished            : logi [1:526] FALSE FALSE FALSE FALSE FALSE FALSE ...
 $ match_status_start_time_str      : chr [1:526] "18:00" "20:30" "14:00" "11:30" ...
 $ match_status_start_date_str      : chr [1:526] "Oct 17, 2022" "Oct 17, 2022" "Oct 17, 2022" "Oct 17, 2022" ...
 $ match_status_start_date_str_short: chr [1:526] "17. Oct." "17. Oct." "17. Oct." "17. Oct." ...
 $ match_time_ts                    : num [1:526] 1.67e+12 1.67e+12 1.67e+12 1.67e+12 1.67e+12 ...
 $ parent_league_id                 : int [1:526] 130 130 NA NA NA 112 112 112 112 112 ...
 $ internal_rank                    : int [1:526] 10 10 10 9 9 9 9 9 9 9 ...
 $ live_rank                        : int [1:526] 100 100 100 100 100 0 0 0 0 0 ...
 $ simple_league                    : logi [1:526] FALSE FALSE FALSE FALSE FALSE FALSE ...
 $ is_group                         : logi [1:526] NA NA NA NA NA NA ...
 $ group_name                       : chr [1:526] NA NA NA NA ...
 $ parent_league_name               : chr [1:526] NA NA NA NA ...
 $ match_tv                         : logi [1:526] NA NA NA NA NA NA ...
 $ match_status_aggregated_str      : chr [1:526] NA NA NA NA ...
```