### PR TITLE
home_away incorrect for some games #219

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.1.7000
+Version: 0.6.1.8000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * `fotmob_get_season_stats` internals changed to handle new data format  (0.6.1.5000)
 * `tm_staff_job_history()` code changed due to HTML changes on transfermarkt.com (0.6.1.6000)
 * All FBRef functions calling internal function `.get_match_report_page()` were returning 'Major League Soccer' as the away team (0.6.1.7000) [#216](https://github.com/JaseZiv/worldfootballR/issues/216)
+* `fb_match_shooting()` was returning the wrong home or away designation in games where team names were inconsistent on the page (0.6.1.8000) [#219](https://github.com/JaseZiv/worldfootballR/issues/219)
 
 
 ### Improvements

--- a/R/get_match_shooting.R
+++ b/R/get_match_shooting.R
@@ -78,19 +78,20 @@ fb_match_shooting <- function(match_url, time_pause=3) {
 
       home_shot_df <- tryCatch(all_shots[2] %>% rvest::html_nodes("table") %>% rvest::html_table() %>% data.frame(), error = function(e) data.frame())
       if(nrow(home_shot_df > 0)) {
-        home_shot_df <- prep_shot_df(home_shot_df)
+        home_shot_df <- prep_shot_df(home_shot_df) %>%
+          dplyr::mutate(Home_Away = "Home")
       }
 
       away_shot_df <- tryCatch(all_shots[3] %>% rvest::html_nodes("table") %>% rvest::html_table() %>% data.frame(), error = function(e) data.frame())
       if(nrow(away_shot_df > 0)) {
-        away_shot_df <- prep_shot_df(away_shot_df)
+        away_shot_df <- prep_shot_df(away_shot_df) %>%
+          dplyr::mutate(Home_Away = "Away")
       }
 
       all_shot_df <- home_shot_df %>%
         rbind(away_shot_df)
 
       all_shot_df <- all_shot_df %>%
-        dplyr::mutate(Home_Away = ifelse(.data[["Squad"]] == home_team, "Home", "Away")) %>%
         dplyr::select(.data[["Date"]], .data[["Squad"]], .data[["Home_Away"]], .data[["Match_Half"]], dplyr::everything())
     } else {
       print(glue::glue("Detailed shot data unavailable for {match_url}"))


### PR DESCRIPTION
Fixing an issue where team names are inconsistent on match pages, leading to all teams being designated `Away` when the home team name is inconsistent... see this page if you wanted an example https://fbref.com/en/matches/e62685d4/Manchester-United-Leeds-United-August-14-2021-Premier-League

`Manchester United` is the home team, however in the shot log table, they're `Manchester Utd`... have made this more robust now