### PR TITLE
Fix #226 (future match lineups from fotmob)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2
+Version: 0.6.2.1000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# worldfootballR 0.6.2.1000
+### Bugs
+
+* `fotmob_get_match_players()` was failing for upcoming matches due to a missing `stats` column [#226](https://github.com/JaseZiv/worldfootballR/issues/226)
+
 # worldfootballR 0.6.2
 
 ### Bugs

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -112,7 +112,7 @@ fotmob_get_match_players <- function(match_ids) {
       }
 
       stats <- if(is.null(ps)) {
-        NULL
+        list(NULL)
       } else {
 
         pss <- ps %>% purrr::map_dfr(.clean_stats)
@@ -222,8 +222,7 @@ fotmob_get_match_players <- function(match_ids) {
     }
     res <- coerce_team_id(res, "home")
     res <- coerce_team_id(res, "away")
-    res <- res %>% tidyr::unnest_wider(.data[["stats"]])
-    res
+    tidyr::unnest_wider(res, .data[["stats"]])
   }
 
   fp <- purrr::possibly(f, otherwise = tibble::tibble())


### PR DESCRIPTION
Fixed an issue with retrieving player data for future matches with `fotmob_get_match_players` due to the default value of `stats` (use `list(NULL)` instead of `NULL` so that `unnest_wider(data, stats)` works)

```r
packageVersion("worldfootballR")
#> [1] '0.6.1.5000'

options(tibble.print_min = 22)
fotmob_get_match_players(3370555) |> 
  dplyr::select(
    team_name,
    shirt,
    first_name,
    last_name,
    role
  )
```

```
# A tibble: 22 × 5
   team_name shirt first_name last_name role      
   <chr>     <chr> <chr>      <chr>     <chr>     
 1 Japan     12    Shuichi    Gonda     Keeper    
 2 Japan     16    Takehiro   Tomiyasu  Defender  
 3 Japan     3     Shogo      Taniguchi Defender  
 4 Japan     22    Maya       Yoshida   Defender  
 5 Japan     14    Junya      Ito       Attacker  
 6 Japan     13    Hidemasa   Morita    Midfielder
 7 Japan     17    Ao         Tanaka    Midfielder
 8 Japan     5     Yuto       Nagatomo  Defender  
 9 Japan     8     Ritsu      Doan      Attacker  
10 Japan     15    Daichi     Kamada    Midfielder
11 Japan     25    Daizen     Maeda     Attacker  
12 Croatia   4     Ivan       Perisic   Midfielder
13 Croatia   14    Marko      Livaja    Attacker  
14 Croatia   9     Andrej     Kramaric  Attacker  
15 Croatia   8     Mateo      Kovacic   Midfielder
16 Croatia   11    Marcelo    Brozovic  Midfielder
17 Croatia   10    Luka       Modric    Midfielder
18 Croatia   19    Borna      Sosa      Defender  
19 Croatia   20    Josko      Gvardiol  Defender  
20 Croatia   6     Dejan      Lovren    Defender  
21 Croatia   22    Josip      Juranovic Defender  
22 Croatia   1     Dominik    Livakovic Keeper 
```