### PR TITLE
Fix #229 and fotmob tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.1000
+Version: 0.6.2.2000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,9 @@
-# worldfootballR 0.6.2.2000
-### Bugs
+# worldfootballR (development version)
 
-* `fotmob_get_league_matches()` was failing due to an extra `purrr::map_dfr` that is no longer needed [#229](https://github.com/JaseZiv/worldfootballR/issues/229)
-
-# worldfootballR 0.6.2.1000
 ### Bugs
 
 * `fotmob_get_match_players()` was failing for upcoming matches due to a missing `stats` column [#226](https://github.com/JaseZiv/worldfootballR/issues/226)
-
+* `fotmob_get_league_matches()` was failing due to an extra `purrr::map_dfr` that is no longer needed [#229](https://github.com/JaseZiv/worldfootballR/issues/229)
 # worldfootballR 0.6.2
 
 ### Bugs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# worldfootballR 0.6.2.2000
+### Bugs
+
+* `fotmob_get_league_matches()` was failing due to an extra `purrr::map_dfr` that is no longer needed [#229](https://github.com/JaseZiv/worldfootballR/issues/229)
+
 # worldfootballR 0.6.2.1000
 ### Bugs
 

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -10,10 +10,10 @@
 #' @importFrom purrr transpose map_dfr
 #' @importFrom dplyr filter
 .fotmob_get_league_urls <- function(
-  leagues,
-  league_id = NULL,
-  country = NULL,
-  league_name = NULL
+    leagues,
+    league_id = NULL,
+    country = NULL,
+    league_name = NULL
 ) {
   has_country <- !is.null(country)
   has_league_name <- !is.null(league_name)
@@ -246,11 +246,10 @@ fotmob_get_league_matches <- function(country, league_name, league_id, cached = 
 .fotmob_get_league_matches <- function(league_id, page_url) {
   resp <- .fotmob_get_league_resp(league_id, page_url)
   rounds <- resp$matches$data$matchesCombinedByRound
-  rounds %>%
-    purrr::map_dfr(
-      ~purrr::map_dfr(.x, dplyr::bind_rows) %>%
-        dplyr::mutate(across(.data[["roundName"]], as.character))
-    ) %>%
+  purrr::map_dfr(
+    rounds,
+    ~dplyr::mutate(.x, dplyr::across(.data[["roundName"]], as.character)),
+   ) %>%
     janitor::clean_names() %>%
     tibble::as_tibble()
 }

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -20,7 +20,7 @@ test_that("fotmob_get_matches_by_date() works", {
 test_that("fotmob_get_league_matches() works", {
   testthat::skip_on_cran()
 
-  expected_league_matches_cols <- c("month_key", "round", "round_name", "page_url", "id", "home", "away", "status")
+  expected_league_matches_cols <- c("round", "round_name", "page_url", "id", "home", "away", "status")
   epl_league_matches <- fotmob_get_league_matches(
     country = "ENG",
     league_name = "Premier League"
@@ -350,7 +350,7 @@ test_that("fotmob_get_season_stats() works", {
 test_that("fotmob_get_match_info() works", {
   testthat::skip_on_cran()
 
-  expected_match_info_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color", "match_date_date_formatted", "match_date_time_formatted", "tournament_id", "tournament_link", "tournament_league_name", "tournament_round", "stadium_name", "stadium_city", "stadium_country", "stadium_lat", "stadium_long", "referee_img_url", "referee_text", "referee_country", "attendance")
+  expected_match_info_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color", "match_date_utc_time", "tournament_id", "tournament_link", "tournament_league_name", "tournament_round", "stadium_name", "stadium_city", "stadium_country", "stadium_lat", "stadium_long", "referee_img_url", "referee_text", "referee_country", "attendance")
   match_info <- fotmob_get_match_info(c(3609987, 3609979))
 
   expect_gt(nrow(match_info), 0)


### PR DESCRIPTION
`fotmob_get_league_matches()` was failing due to an extra `purrr::map_dfr` that is no longer needed [#229](https://github.com/JaseZiv/worldfootballR/issues/229)

Also, I updated some of the fotmob tests that were failing due to changes in the column names provided by Fotmob.