### PR TITLE
Changed transfer_history logic + added case 'k' in MV conversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.3000
+Version: 0.6.2.4000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Suggests:
     rmarkdown,
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # worldfootballR (development version)
 
+### Improvements / Breaking Changes
+
+* `tm_player_transfer_history()` now contains an additional column in the returned dataframe (`transfer_type`). This column differentiate between regular transfers, free transfers, loans and paid loans and transfers due to players returning from loan.
+
 ### Bugs
 
 * `fotmob_get_match_players()` was failing for upcoming matches due to a missing `stats` column (0.6.2.1000) [#226](https://github.com/JaseZiv/worldfootballR/issues/226)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * `check_league_name()` removes repeated code. It checks that the name of the leagues is correct [#232](https://github.com/JaseZiv/worldfootballR/pull/232)
 * `LEAGUES` replaces **if** statement with list [#232](https://github.com/JaseZiv/worldfootballR/pull/232)
+* `tm_player_transfer_history()` added information about countries involved in the transfer, added possibility to skip extra info extraction. [#235](https://github.com/JaseZiv/worldfootballR/pull/235)
 
 # worldfootballR 0.6.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # worldfootballR (development version)
 
-### Improvements / Breaking Changes
+### Breaking Changes
 
 * `tm_player_transfer_history()` now contains an additional column in the returned dataframe (`transfer_type`). This column differentiate between regular transfers, free transfers, loans and paid loans and transfers due to players returning from loan.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * `check_league_name()` removes repeated code. It checks that the name of the leagues is correct [#232](https://github.com/JaseZiv/worldfootballR/pull/232)
 * `LEAGUES` replaces **if** statement with list [#232](https://github.com/JaseZiv/worldfootballR/pull/232)
-* `tm_player_transfer_history()` added information about countries involved in the transfer, added possibility to skip extra info extraction. [#235](https://github.com/JaseZiv/worldfootballR/pull/235)
+* `tm_player_transfer_history()` added more information, added possibility to skip extraction of info that requires additional page load time. [#235](https://github.com/JaseZiv/worldfootballR/pull/235)
 
 # worldfootballR 0.6.2
 

--- a/R/internals.R
+++ b/R/internals.R
@@ -231,6 +231,8 @@
   clean_val <- gsub("[^\x20-\x7E]", "", euro_value) %>% tolower()
   if(grepl("free", clean_val)) {
     clean_val <- 0
+  } else if(grepl("loan fee", clean_val)) {
+    clean_val <- suppressWarnings(gsub("loan fee:", "", clean_val)) %>% .convert_value_to_numeric
   } else if(grepl("m", clean_val)) {
     clean_val <- suppressWarnings(gsub("m", "", clean_val) %>% as.numeric() * 1000000)
   } else if(grepl("th.", clean_val)) {

--- a/R/internals.R
+++ b/R/internals.R
@@ -235,6 +235,8 @@
     clean_val <- suppressWarnings(gsub("m", "", clean_val) %>% as.numeric() * 1000000)
   } else if(grepl("th.", clean_val)) {
     clean_val <- suppressWarnings(gsub("th.", "", clean_val) %>% as.numeric() * 1000)
+  } else if(grepl("k", clean_val)) {
+    clean_val <- suppressWarnings(gsub("k", "", clean_val) %>% as.numeric() * 1000)
   } else {
     clean_val <- suppressWarnings(as.numeric(clean_val) * 1)
   }

--- a/R/player_transfer_history.R
+++ b/R/player_transfer_history.R
@@ -4,6 +4,7 @@
 #' Replaces the deprecated function player_transfer_history
 #'
 #' @param player_urls the player url(s) from transfermarkt
+#' @param get_extra_info allows users to decide if they want to scrape extra info (contract length, countries involved) or not
 #'
 #' @return returns a dataframe of player transfers
 #'

--- a/man/tm_player_transfer_history.Rd
+++ b/man/tm_player_transfer_history.Rd
@@ -4,10 +4,12 @@
 \alias{tm_player_transfer_history}
 \title{Get Transfermarkt player transfer history}
 \usage{
-tm_player_transfer_history(player_urls)
+tm_player_transfer_history(player_urls, get_extra_info = TRUE)
 }
 \arguments{
 \item{player_urls}{the player url(s) from transfermarkt}
+
+\item{get_extra_info}{allows users to decide if they want to scrape extra info (contract length, countries involved) or not}
 }
 \value{
 returns a dataframe of player transfers

--- a/vignettes/extract-transfermarkt-data.Rmd
+++ b/vignettes/extract-transfermarkt-data.Rmd
@@ -304,6 +304,29 @@ dplyr::glimpse(hazard_injuries)
 ```
 
 
+### Player Transfer History
+
+To be able to get an individual player(s) transfer history from transfermarkt, use the `tm_player_transfer_history()` function.
+
+The parameter `get_extra_info` allows users to decide if they want to scrape the extra info regarding the transfer. This will give additional information regarding contract length and nations involved, but will require more time. The default value is `TRUE`.
+
+
+```{r player_transfer_history}
+#----- for a single player, get_extra_info defaulting TRUE: -----#
+jack_rodwell_transfer_history <- tm_player_transfer_history(player_urls = "https://www.transfermarkt.com/jack-rodwell/profil/spieler/57079")
+dplyr::glimpse(jack_rodwell_transfer_history)
+
+#----- for a single player, get_extra_info FALSE: -----#
+jack_rodwell_transfer_history <- tm_player_transfer_history(player_urls = "https://www.transfermarkt.com/jack-rodwell/profil/spieler/57079", get_extra_info = FALSE)
+dplyr::glimpse(jack_rodwell_transfer_history)
+
+#----- for multiple players, get_extra_info FALSE: -----#
+all_leeds_united_links <- tm_team_player_urls(team_url = "https://www.transfermarkt.com/leeds-united/startseite/verein/399")
+all_leeds_united_players_transfer_history <- tm_player_transfer_history(all_leeds_united_links, get_extra_info = FALSE)
+dplyr::glimpse(all_leeds_united_players_transfer_history)
+```
+
+
 ***
 
 


### PR DESCRIPTION
First of all, I had problems scraping market values as I have 'k' instead of 'th' when talking thousands (€500k instead of €500th for example) so I added that case in `.convert_value_to_numeric`.

Then I added a parameter in `tm_player_transfer_history`, defaulting to true, to allow users to avoid scraping extra info that increase hugely the computation time of the function. From my latest tests on more obscure players sometimes the function needs 40/50s to be executed due to multiple calls to `extra_info <- tryCatch(xml2::read_html(extra_info_url), error = function(e) NA)`. 

The country_to/from field is no more obtainable from the initial summary page, but the information is present in (most) transfer details views, so now the country will be scraped if `get_extra_info` is `TRUE`. 

_______

Some explanations about the function: the div containing the `country_from` info has no unique class, meaning that at best I can get both the countries (from and to) thanks to the `.flaggenrahmen` class. Which wouldn't be a problem if only they were always there, I could just always get the first value as `country_from` and the second value as `country_to`. Sometimes though the first/second country is not there and there is no placeholder to indicate that. Meaning that when scraping the countries I'll get only one value. How to understand if this value is related to the club from or the club to which the transfer is happening? The div containing `country_to` instead has a specific class, which allows me to get the specific value. Basically if `country_to` is NA and `countries` contains 1 value, then the value is related to `country_from`. If `country_to` is not NA and we have only one value, then `country_from` has to be NA.