### PR TITLE
Improve messaging for silent failures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.7100
+Version: 0.6.2.8000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,8 +19,8 @@
 * `LEAGUES` replaces **if** statement with list (0.6.2.3000) [#232](https://github.com/JaseZiv/worldfootballR/pull/232)
 * `tm_player_transfer_history()` added more information, added possibility to skip extraction of info that requires additional page load time. (0.6.2.4000) [#235](https://github.com/JaseZiv/worldfootballR/pull/235)
 * `fb_league_stats()` added. Gets season stats for all teams / players in a selected league from FBref in a single scrape. (0.6.2.6000) [#243](https://github.com/JaseZiv/worldfootballR/pull/243)
-  * `fb_league_stats()` uses `rvest::htm_table()` if `team_or_player = "table"` (faster and more reliable), and only uses chromote if `team_or_player = "player"`. (0.6.2.7100)
-  * Use `quiet = FALSE` in all `purrr::possibly()` calls internally. Improve messaging for unexpected outcomes in `fotmob_get_matches_by_date()` and `fotmob_get_match_info()`. (0.6.2.8000) [#244](https://github.com/JaseZiv/worldfootballR/pull/244)
+* `fb_league_stats()` uses `rvest::htm_table()` if `team_or_player = "table"` (faster and more reliable), and only uses chromote if `team_or_player = "player"`. (0.6.2.7100)
+* Use `quiet = FALSE` in all `purrr::possibly()` calls internally. Improve messaging for unexpected outcomes in `fotmob_get_matches_by_date()` and `fotmob_get_match_info()`. (0.6.2.8000) [#244](https://github.com/JaseZiv/worldfootballR/pull/244)
 
 # worldfootballR 0.6.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * `tm_player_transfer_history()` added more information, added possibility to skip extraction of info that requires additional page load time. (0.6.2.4000) [#235](https://github.com/JaseZiv/worldfootballR/pull/235)
 * `fb_league_stats()` added. Gets season stats for all teams / players in a selected league from FBref in a single scrape. (0.6.2.6000) [#243](https://github.com/JaseZiv/worldfootballR/pull/243)
   * `fb_league_stats()` uses `rvest::htm_table()` if `team_or_player = "table"` (faster and more reliable), and only uses chromote if `team_or_player = "player"`. (0.6.2.7100)
+  * Use `quiet = FALSE` in all `purrr::possibly()` calls internally. Improve messaging for unexpected outcomes in `fotmob_get_matches_by_date()` and `fotmob_get_match_info()`. (0.6.2.8000) [#244](https://github.com/JaseZiv/worldfootballR/pull/244)
 
 # worldfootballR 0.6.2
 

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -86,14 +86,16 @@ fotmob_get_matches_by_date <- function(dates) {
     url <- paste0(main_url, "matches?date=", date)
 
     resp <- safely_from_json(url)$result
-    res <- resp$leagues %>%
-      janitor::clean_names() %>%
-      tibble::as_tibble()
-    if(nrow(res) == 0) {
-      stop(sprintf("Couldn't find match data for `date = %d`.", orig_date))
+
+    res <- resp$leagues
+    if(is.null(res)) {
+      stop(sprintf("Couldn't find match data for `date = %s`.", orig_date))
       return(res)
     }
+
     res %>%
+      janitor::clean_names() %>%
+      tibble::as_tibble() %>%
       dplyr::rename(match = .data[["matches"]]) %>%
       tidyr::unnest(.data[["match"]], names_sep = "_") %>%
       dplyr::rename(home = .data[["match_home"]], away = .data[["match_away"]]) %>%

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -89,7 +89,7 @@ fotmob_get_matches_by_date <- function(dates) {
 
     res <- resp$leagues
     if(is.null(res)) {
-      stop(sprintf("Couldn't find match data for `date = %s`.", orig_date))
+      stop(sprintf('Couldn\'t find match data for `date = "%s"`.', orig_date))
       return(res)
     }
 

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -73,18 +73,24 @@ fotmob_get_matches_by_date <- function(dates) {
 
   main_url <- "https://www.fotmob.com/api/"
 
-  is_date <- lubridate::is.Date(date)
-  if(is_date) {
-    date <- lubridate::ymd(date)
-  }
-  date <- stringr::str_remove_all(as.character(date), "-")
-  url <- paste0(main_url, "matches?date=", date)
-  f <- function(url) {
+  f <- function(date) {
+
+    orig_date <- date
+    is_date <- lubridate::is.Date(date)
+    if(is_date) {
+      date <- lubridate::ymd(date)
+    }
+
+    date <- stringr::str_remove_all(as.character(date), "-")
+
+    url <- paste0(main_url, "matches?date=", date)
+
     resp <- safely_from_json(url)$result
     res <- resp$leagues %>%
       janitor::clean_names() %>%
       tibble::as_tibble()
     if(nrow(res) == 0) {
+      stop(sprintf("Couldn't find match data for `date = %d`.", orig_date))
       return(res)
     }
     res %>%
@@ -95,8 +101,12 @@ fotmob_get_matches_by_date <- function(dates) {
       dplyr::select(-tidyselect::vars_select_helpers$where(is.list)) %>%
       janitor::clean_names()
   }
-  fp <- purrr::possibly(f, otherwise = tibble::tibble())
-  fp(url)
+  fp <- purrr::possibly(
+    f,
+    otherwise = tibble::tibble(),
+    quiet = FALSE
+  )
+  fp(date)
 }
 
 #' Get fotmob match details by match id
@@ -162,7 +172,11 @@ fotmob_get_match_details <- function(match_ids) {
     df
   }
 
-  fp <- purrr::possibly(f, otherwise = tibble::tibble())
+  fp <- purrr::possibly(
+    f,
+    quiet = FALSE,
+    otherwise = tibble::tibble()
+  )
   fp(url)
 }
 
@@ -234,7 +248,11 @@ fotmob_get_match_team_stats <- function(match_ids) {
     df
   }
 
-  fp <- purrr::possibly(f, otherwise = tibble::tibble())
+  fp <- purrr::possibly(
+    f,
+    quiet = FALSE,
+    otherwise = tibble::tibble()
+  )
   fp(url)
 }
 
@@ -273,9 +291,10 @@ fotmob_get_match_info <- function(match_ids) {
 #' @importFrom tidyr pivot_wider unnest unnest_wider
 .fotmob_get_single_match_info <- function(match_id) {
   main_url <- "https://www.fotmob.com/api/"
-  url <- paste0(main_url, "matchDetails?matchId=", match_id)
 
-  f <- function(url) {
+  f <- function(match_id) {
+
+    url <- paste0(main_url, "matchDetails?matchId=", match_id)
 
     general <- .extract_fotmob_match_general(url)
     df <- dplyr::bind_cols(
@@ -302,12 +321,17 @@ fotmob_get_match_info <- function(match_ids) {
       janitor::clean_names()
 
     if (nrow(df) != 1) {
+      stopf(sprintf("Could not find match info for `match_id = %s`", match_id))
       return(tibble::tibble())
     }
 
     dplyr::bind_cols(df, unnested_info)
   }
 
-  fp <- purrr::possibly(f, otherwise = tibble::tibble())
-  fp(url)
+  fp <- purrr::possibly(
+    f,
+    quiet = FALSE,
+    otherwise = tibble::tibble()
+  )
+  fp(match_id)
 }

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -225,6 +225,10 @@ fotmob_get_match_players <- function(match_ids) {
     tidyr::unnest_wider(res, .data[["stats"]])
   }
 
-  fp <- purrr::possibly(f, otherwise = tibble::tibble())
+  fp <- purrr::possibly(
+    f,
+    quiet = FALSE,
+    otherwise = tibble::tibble()
+  )
   fp(url)
 }

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -200,7 +200,12 @@
         )
       )
     }
-    possibly_extract_options <- purrr::possibly(extract_options, otherwise = tibble::tibble(), quiet = TRUE)
+
+    possibly_extract_options <- purrr::possibly(
+      extract_options,
+      otherwise = tibble::tibble(),
+      quiet = FALSE
+    )
 
     valid_seasons %>%
       purrr::map_dfr(possibly_extract_options) %>%

--- a/R/understat_teams.R
+++ b/R/understat_teams.R
@@ -47,7 +47,7 @@ understat_team_players_stats <- function(team_url) {
 #'
 #' @export
 understat_team_stats_breakdown <- function(team_urls) {
-  f_possibly <- purrr::possibly(.understat_team_stats_breakdown, otherwise = data.frame())
+  f_possibly <- purrr::possibly(.understat_team_stats_breakdown, otherwise = data.frame(), quiet = FALSE)
   purrr::map_dfr(team_urls, f_possibly)
 }
 

--- a/R/worldfootballr_helpers.R
+++ b/R/worldfootballr_helpers.R
@@ -287,7 +287,7 @@ tm_team_staff_urls <- function(team_urls, staff_role) {
 #' })
 #' }
 understat_team_meta <- function(team_names) {
-  f_possibly <- purrr::possibly(.understat_team_meta, otherwise = data.frame())
+  f_possibly <- purrr::possibly(.understat_team_meta, otherwise = data.frame(), quiet = FALSE)
   purrr::map_dfr(team_names, f_possibly)
 }
 


### PR DESCRIPTION
Use `quiet = FALSE` in all `purrr::possibly()` calls internally. Improve messaging for unexpected outcomes in `fotmob_get_matches_by_date()` and `fotmob_get_match_info()`.

Addresses #244.