### PR TITLE
Fix `fotmob_get_match_details()` for matches without shot details

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.9200
+Version: 0.6.2.9300
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * All understat functions were failing due to a new cookie requirement (0.6.2.5000) [#239](https://github.com/JaseZiv/worldfootballR/issues/239)
 * `fb_player_scouting_report()` failing due to HTML changes on FBRef (0.6.2.7000) [#242](https://github.com/JaseZiv/worldfootballR/issues/242)
 * `fb_league_stats(team_or_player = "player", stat_type = "standard", ...)` failing since `"standard"` should be translated to `"stats"` (0.6.2.9100) [#252](https://github.com/JaseZiv/worldfootballR/issues/252)
+* `fotmob_get_match_details()` returned 0 rows instead of 1 when there are no shots available (0.6.2.9300)
 
 ### Improvements
 

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -158,11 +158,12 @@ fotmob_get_match_details <- function(match_ids) {
       general$scalars,
       general$teams
     )
-
-    shots <- general$resp$content$shotmap$shots %>% janitor::clean_names()
-    has_shots <- length(shots) > 0
     df <- tibble::as_tibble(df)
+    shots <- general$resp$content$shotmap$shots
+    has_shots <- length(shots) > 0
+
     if(isTRUE(has_shots)) {
+      shots <- janitor::clean_names(shots)
       df$shots <- list(shots)
       df <- df %>%
         tidyr::unnest(.data[["shots"]])  %>%

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -422,7 +422,7 @@ test_that("fotmob_get_match_details() works", {
   testthat::skip_on_cran()
 
   expected_match_detail_nonshot_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color")
-  expected_match_detail_cols <- c("id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio", "first_name", "last_name", "team_color")
+  expected_match_detail_shot_cols <- c("id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio", "first_name", "last_name", "team_color")
   expected_match_detail_cols <- c(expected_match_detail_nonshot_cols, expected_match_detail_shot_cols)
   details <- fotmob_get_match_details(c(3609987, 3609979))
 

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -421,7 +421,9 @@ test_that("fotmob_get_match_team_stats() works", {
 test_that("fotmob_get_match_details() works", {
   testthat::skip_on_cran()
 
-  expected_match_detail_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color", "id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio", "first_name", "last_name", "team_color")
+  expected_match_detail_nonshot_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color")
+  expected_match_detail_cols <- c("id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio", "first_name", "last_name", "team_color")
+  expected_match_detail_cols <- c(expected_match_detail_nonshot_cols, expected_match_detail_shot_cols)
   details <- fotmob_get_match_details(c(3609987, 3609979))
 
   expect_gt(nrow(details), 0)
@@ -431,6 +433,11 @@ test_that("fotmob_get_match_details() works", {
   details <- fotmob_get_match_details(3846342)
   expect_gt(nrow(details), 0)
   expect_setequal(colnames(details), expected_match_detail_cols)
+
+  ## match with no shots
+  details <- fotmob_get_match_details(3361745)
+  expect_equal(nrow(details), 1)
+  expect_setequal(colnames(details), expected_match_detail_nonshot_cols)
 })
 
 test_that("fotmob_get_match_players() works", {


### PR DESCRIPTION
I realized that the issue with [the fotmob match details scraper](https://github.com/JaseZiv/worldfootballR_data/actions/runs/4158784531/jobs/7194236210) returning lots of errors for `janitor::clean_names()` is due to some faulty logic for handling matches without shots. I've addressed this, which should eliminate all the errors I was seeing in the data repo's GitHub Action.