### PR TITLE
Fix `fotmob_get_league_matches()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.9300
+Version: 0.6.2.9400
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * `fb_player_scouting_report()` failing due to HTML changes on FBRef (0.6.2.7000) [#242](https://github.com/JaseZiv/worldfootballR/issues/242)
 * `fb_league_stats(team_or_player = "player", stat_type = "standard", ...)` failing since `"standard"` should be translated to `"stats"` (0.6.2.9100) [#252](https://github.com/JaseZiv/worldfootballR/issues/252)
 * `fotmob_get_match_details()` returned 0 rows instead of 1 when there are no shots available (0.6.2.9300)
+* `fotmob_get_league_matches()` changed to use `matches.allMatches` JSON element (0.6.2.9400) [#258](https://github.com/JaseZiv/worldfootballR/issues/258)
 
 ### Improvements
 

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -303,11 +303,8 @@ fotmob_get_league_matches <- function(country, league_name, league_id, season = 
     season = season
   )
   .fotmob_message_for_season(resp, season)
-  rounds <- resp$matches$data$matchesCombinedByRound
-  purrr::map_dfr(
-    rounds,
-    ~dplyr::mutate(.x, dplyr::across(.data[["roundName"]], as.character)),
-  ) %>%
+  matches <- resp$matches$allMatches
+  matches %>%
     janitor::clean_names() %>%
     tibble::as_tibble()
 }

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -391,7 +391,7 @@ test_that("fotmob_get_season_stats() works", {
 test_that("fotmob_get_match_info() works", {
   testthat::skip_on_cran()
 
-  expected_match_info_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color", "match_date_utc_time", "tournament_id", "tournament_link", "tournament_league_name", "tournament_round", "stadium_name", "stadium_city", "stadium_country", "stadium_lat", "stadium_long", "referee_img_url", "referee_text", "referee_country", "attendance")
+  expected_match_info_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color", "match_date_utc_time", "tournament_id", "tournament_link", "tournament_league_name", "tournament_round", "tournament_selected_season", "tournament_is_current_season", "stadium_name", "stadium_city", "stadium_country", "stadium_lat", "stadium_long", "referee_img_url", "referee_text", "referee_country", "attendance")
   match_info <- fotmob_get_match_info(c(3609987, 3609979))
 
   expect_gt(nrow(match_info), 0)


### PR DESCRIPTION
It seems that they removed/renamed the `matches.data.matchesCombinedByRound` element...

Fixes #258 