### PR TITLE
Fix Fotmob functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.2.9400
+Version: 0.6.3.0000
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * `fb_league_stats(team_or_player = "player", stat_type = "standard", ...)` failing since `"standard"` should be translated to `"stats"` (0.6.2.9100) [#252](https://github.com/JaseZiv/worldfootballR/issues/252)
 * `fotmob_get_match_details()` returned 0 rows instead of 1 when there are no shots available (0.6.2.9300)
 * `fotmob_get_league_matches()` changed to use `matches.allMatches` JSON element (0.6.2.9400) [#258](https://github.com/JaseZiv/worldfootballR/issues/258)
+* All fotmob functions updated to use `httr::GET()` with appropriate post-processing of JSON instead of `jsonlite::fromJSON()` with raw URLs (0.6.3.0000) [#262](https://github.com/JaseZiv/worldfootballR/issues/262)
 
 ### Improvements
 
@@ -26,6 +27,7 @@
 * Use `quiet = FALSE` in all `purrr::possibly()` calls internally. Improve messaging for unexpected outcomes in `fotmob_get_matches_by_date()` and `fotmob_get_match_info()`. (0.6.2.8000) [#244](https://github.com/JaseZiv/worldfootballR/pull/244)
 * `load_fb_match_shooting()` added. (0.6.2.9000) [#249](https://github.com/JaseZiv/worldfootballR/pull/249)
 * `fotmob_get_league_matches()` and `fotmob_get_league_tables` gain a `season` parameter. (0.6.2.9200) [#256](https://github.com/JaseZiv/worldfootballR/pull/256)
+* `fotmob_get_season_stats()` internals improved (0.6.3.0000)
 
 # worldfootballR 0.6.2
 

--- a/R/fotmob_helpers.R
+++ b/R/fotmob_helpers.R
@@ -17,6 +17,6 @@
   meta <- .fotmob_extract_meta()
   meta %>%
     stringr::str_extract('(?<=\\"buildId\\"[:]).*(?=\\,\\"isFallback\\")') %>%
-    safely_from_json() %>%
+    safely_get_content() %>%
     pluck("result")
 }

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -142,16 +142,6 @@ fotmob_get_league_ids <- function(cached = TRUE) {
   )
 }
 
-#' @importFrom stringr str_replace
-.fotmob_get_league_resp_from_build_id <- function(page_url, stats = FALSE) {
-  build_id <- .fotmob_get_build_id()
-  url <- sprintf("https://www.fotmob.com/_next/data/%s%s.json", build_id, page_url)
-  if(stats) {
-    url <- stringr::str_replace(url, "overview", "stats")
-  }
-  safely_get_content(url)
-}
-
 #' @importFrom purrr safely
 #' @importFrom httr parse_url build_url
 #' @importFrom rlang inform
@@ -168,21 +158,8 @@ fotmob_get_league_ids <- function(cached = TRUE) {
     return(resp$result)
   }
 
-  first_url <- url
-  if(fallback) {
-    if (!is.null(season)) {
-      rlang::inform(
-        glue::glue('`season` ignored in call to "{page_url}".')
-      )
-    }
-    resp <- .fotmob_get_league_resp_from_build_id(page_url)
-    if(!is.null(resp$result)) {
-      return(resp$result)
-    }
-  }
-
   stop(
-    sprintf("Could not identify the league endpoint at either %s or %s. Stopping with the following error from jsonlite::fromJSON:\n", first_url, url, res$error)
+    sprintf("Could not identify the league endpoint at %s. Error:\n", url, res$error)
   )
 }
 

--- a/R/fotmob_leagues.R
+++ b/R/fotmob_leagues.R
@@ -149,7 +149,7 @@ fotmob_get_league_ids <- function(cached = TRUE) {
   if(stats) {
     url <- stringr::str_replace(url, "overview", "stats")
   }
-  safely_from_json(url)
+  safely_get_content(url)
 }
 
 #' @importFrom purrr safely
@@ -163,7 +163,7 @@ fotmob_get_league_ids <- function(cached = TRUE) {
     "season" = season
   )
   url <- httr::build_url(url)
-  resp <- safely_from_json(url)
+  resp <- safely_get_content(url)
   if(!is.null(resp$result)) {
     return(resp$result)
   }

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -1,5 +1,5 @@
 .extract_fotmob_match_general <- function(url) {
-  resp <- safely_from_json(url)$result
+  resp <- safely_get_content(url)$result
   general <- resp$general
   scalars <- data.frame(
     stringsAsFactors = FALSE,
@@ -85,7 +85,7 @@ fotmob_get_matches_by_date <- function(dates) {
 
     url <- paste0(main_url, "matches?date=", date)
 
-    resp <- safely_from_json(url)$result
+    resp <- safely_get_content(url)$result
 
     res <- resp$leagues
     if(is.null(res)) {

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -61,7 +61,7 @@ fotmob_get_match_players <- function(match_ids) {
   url <- paste0(main_url, "matchDetails?matchId=", match_id)
 
   f <- function(url) {
-    resp <- safely_from_json(url)$result
+    resp <- safely_get_content(url)$result
 
     table <- resp$content$table
     lineup <- resp$content$lineup$lineup

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -18,12 +18,11 @@
 
   resp <- safely_get_content(url)
   if(!is.null(resp$error)) {
-    warning(
+    stop(
       sprintf(
-        'Issue with data at `url = "%s".\n%s', url, resp$error
+        "Error in .fotmob_get_single_season_stats (with %s).\n%s", url, resp$error
       )
     )
-    return(tibble::tibble())
   }
 
   resp$result %>%
@@ -33,12 +32,6 @@
     dplyr::select(.data[["StatList"]]) %>%
     tidyr::unnest(.data[["StatList"]]) %>%
     janitor::clean_names()
-}
-
-.upper1 <- function(x) {
-  x <- tolower(x)
-  substr(x, 1, 1) <- toupper(substr(x, 1, 1))
-  x
 }
 
 #' @importFrom rvest html_text2 html_attr
@@ -77,141 +70,84 @@
     league_name,
     league_id,
     team_or_player,
-    page_url,
     cached
 ) {
 
-  tables <- fotmob_get_league_tables(
+  main_url <- "https://www.fotmob.com/api/"
+  url <- .fotmob_get_league_ids(
     cached = cached,
     country = rlang::maybe_missing(country, NULL),
     league_name = rlang::maybe_missing(league_name, NULL),
     league_id = rlang::maybe_missing(league_id, NULL)
   )
+  url <- paste0(main_url, "leagues?id=", url$id)
 
-  url <- sprintf(
-    "https://www.fotmob.com%s/%ss",
-    stringr::str_replace(tables$page_url[1], "overview", "stats"),
-    team_or_player
-  )
-  page <- url %>% rvest::read_html()
-
-  see_all_button <- page %>% rvest::html_elements(".SeeAllButton")
-  has_see_all_button <- length(see_all_button) > 0
-
-  options <- page %>% rvest::html_elements("option")
-  has_options <- length(options) > 0
-
-  if (has_see_all_button) {
-
-    hrefs <- see_all_button %>% rvest::html_attr("href")
-    next_url <- sprintf(
-      "https://www.fotmob.com%s",
-      hrefs[1]
-    )
-    next_page <- next_url %>% rvest::read_html()
-    options <- next_page %>% rvest::html_elements("option")
-    .extract_seasons_and_stats_from_options(options)
-  } else if (has_options) {
-
-    values <- options %>% rvest::html_attr("value")
-
-    parts <- values %>%
-      purrr::keep(~stringr::str_detect(.x, "season")) %>%
-      stringr::str_split("/")
-
-    if(length(parts) == 0) {
-      rlang::abort(glue::glue("Could not parse season ids from {url}."))
-    }
-
-    if(length(parts[[1]]) < 5) {
-      rlang::abort(glue::glue("Season ids not stored in expected format at {url}."))
-    }
-
-    season_ids <- parts %>%
-      purrr::map_chr(~purrr::pluck(.x, 4))
-
-    ## protect against the current season being in the offseason, unless there is no other season.
-    season_id <- ifelse(length(season_ids) > 1, season_ids[2], season_ids[1])
-    next_url <- sprintf(
-      "https://www.fotmob.com/leagues/%s/stats/season/%s/%ss/saves_team",
-      tables$league_id[1],
-      season_id,
-      team_or_player
-    )
-
-    next_page <- next_url %>% rvest::read_html()
-    next_options <- next_page %>% rvest::html_elements("option")
-    .extract_seasons_and_stats_from_options(next_options)
-
-  } else {
-    resp <- .fotmob_get_league_resp_from_build_id(page_url, stats = TRUE)
-    if(is.null(resp$result)) {
-      stop(
-        sprintf("Can't find season stats data. Failed with the following error:\n", resp$error)
+  resp <- safely_get_content(url)
+  if(!is.null(resp$error)) {
+    stop(
+      sprintf(
+        'Error in `.fotmob_get_stat_and_season_options` with `url = "%s"`.\n%s', url, resp$error
       )
-    }
-    stats <- resp$result$pageProps$stats
-    seasons <- stats$seasonStatLinks$Name
-
-    label <- sprintf("%ss", .upper1(team_or_player))
-    valid_seasons <- setNames(seasons, seasons) %>%
-      purrr::keep(
-        ~.x %in% stats$seasonStatLinks$Name
-      ) %>%
-      names()
-
-    extract_options <- function(season) {
-
-      link <- stats$seasonStatLinks %>%
-        filter(.data[["Name"]] == !!season)
-
-      topstats_url <- sprintf("https://data.fotmob.com/%s", link$RelativePath)
-      topstats <- purrr::map_dfr(topstats_url, safely_get_content) ## Liga MX will have two rows
-      toplists <- topstats$result$TopLists %>%
-        dplyr::distinct(header = .data[["Title"]], name = .data[["StatName"]])
-
-      negate <- ifelse(team_or_player == "team", FALSE, TRUE)
-
-      toplists <- toplists %>%
-        dplyr::filter(stringr::str_detect(.data[["name"]], "team", negate = !!negate))
-
-      season_name <- season
-      if (any(colnames(link) == "Group")) {
-        season_name <- sprintf("%s-%s", season_name, link$Group)
-      }
-
-      season_id <- as.character(link$TournamentId)
-      if (any(colnames(link) == "Group")) {
-        season_id <- sprintf("%s-%s", season_id, link$Group)
-      }
-
-      dplyr::bind_rows(
-        tibble::tibble(
-          league_name = NA_character_,
-          option_type = "season",
-          name = season_name,
-          id = season_id
-        ),
-        tibble::tibble(
-          league_name = NA_character_,
-          option_type = "stat",
-          name = toplists$header,
-          id = toplists$name
-        )
-      )
-    }
-
-    possibly_extract_options <- purrr::possibly(
-      extract_options,
-      otherwise = tibble::tibble(),
-      quiet = FALSE
     )
-
-    valid_seasons %>%
-      purrr::map_dfr(possibly_extract_options) %>%
-      dplyr::distinct() %>%
-      dplyr::arrange(.data[["option_type"]], .data[["name"]])
   }
+
+  res <- resp$result
+  stats <- res$stats
+  stat_links <- stats$seasonStatLinks
+  seasons <- stat_links$Name
+  valid_seasons <- setNames(seasons, seasons)
+
+  extract_options <- function(season) {
+
+    link <- stat_links %>%
+      filter(.data[["Name"]] == !!season)
+
+    topstats_url <- sprintf("https://data.fotmob.com/%s", link$RelativePath)
+    topstats <- purrr::map_dfr(topstats_url, safely_get_content) ## Liga MX will have two rows
+    toplists <- topstats$result$TopLists %>%
+      dplyr::distinct(header = .data[["Title"]], name = .data[["StatName"]])
+
+    negate <- ifelse(team_or_player == "team", FALSE, TRUE)
+
+    toplists <- toplists %>%
+      dplyr::filter(stringr::str_detect(.data[["name"]], "team", negate = !!negate))
+
+    season_name <- season
+    if (any(colnames(link) == "Group")) {
+      season_name <- sprintf("%s-%s", season_name, link$Group)
+    }
+
+    season_id <- as.character(link$TournamentId)
+    if (any(colnames(link) == "Group")) {
+      season_id <- sprintf("%s-%s", season_id, link$Group)
+    }
+
+    dplyr::bind_rows(
+      tibble::tibble(
+        league_name = NA_character_,
+        option_type = "season",
+        name = season_name,
+        id = season_id
+      ),
+      tibble::tibble(
+        league_name = NA_character_,
+        option_type = "stat",
+        name = toplists$header,
+        id = toplists$name
+      )
+    )
+  }
+
+  possibly_extract_options <- purrr::possibly(
+    extract_options,
+    otherwise = tibble::tibble(),
+    quiet = FALSE
+  )
+
+  valid_seasons %>%
+    purrr::map_dfr(possibly_extract_options) %>%
+    dplyr::distinct() %>%
+    dplyr::arrange(.data[["option_type"]], .data[["name"]])
 }
 
 #' Get season statistics from fotmob
@@ -297,7 +233,7 @@
 #' @return returns a dataframe of team or player stats
 #'
 #' @importFrom purrr map_dfr map2_dfr pmap_dfr possibly
-#' @importFrom rlang maybe_missing .data
+#' @importFrom rlang arg_match maybe_missing .data
 #' @importFrom dplyr filter select
 #' @importFrom tibble tibble
 #' @importFrom glue glue_collapse
@@ -326,7 +262,8 @@ fotmob_get_season_stats <- function(
     cached = TRUE
 ) {
 
-  match.arg(team_or_player, several.ok = FALSE)
+  stopifnot('Must specify one of either `"team"` or `"player"` for `team_or_player`' = length(team_or_player) == 1)
+  rlang::arg_match(team_or_player)
   stopifnot("`season_name` cannot be NULL.`" = !is.null(season_name))
 
   urls <- .fotmob_get_league_ids(
@@ -349,27 +286,19 @@ fotmob_get_season_stats <- function(
   }
   urls$stat_league_name <- stat_league_name
 
-  fp <- purrr::possibly(
-    .fotmob_get_single_league_single_season_stats,
-    otherwise = tibble::tibble(),
-    quiet = FALSE
-  )
-
   ## Note that this is written in this awkward fashion (instead of expanding on stat, season_name, AND league_id)
   ##   so that we can re-use the season options for a given league without having to re-scrape it every time
   ##   (if we have multiple stats or seasons for a given league).
-  g <- function(stat_name, season_name, league_id) {
+  f <- function(stat_name, season_name, league_id) {
 
     url <- urls %>% dplyr::filter(.data[["id"]] == !!league_id)
     country <-  url$ccode
     league_name <- url$name
-    page_url <- url$page_url
     options <- .fotmob_get_stat_and_season_options(
       cached = cached,
       country = country,
       league_name = league_name,
       league_id = league_id,
-      page_url = page_url,
       team_or_player = team_or_player
     )
 
@@ -406,7 +335,7 @@ fotmob_get_season_stats <- function(
 
     purrr::map_dfr(
       season_name,
-      ~fp(
+      ~.fotmob_get_single_league_single_season_stats(
         country = country,
         league_name = league_name,
         league_id = league_id,
@@ -437,7 +366,7 @@ fotmob_get_season_stats <- function(
         .y,
         urls$id
       ),
-      ~g(..1, ..2, ..3)
+      ~f(..1, ..2, ..3)
     )
   )
 
@@ -483,13 +412,7 @@ fotmob_get_season_stats <- function(
     )
   }
 
-  fp <- purrr::possibly(
-    .fotmob_get_single_season_stats,
-    quiet = FALSE,
-    otherwise = tibble::tibble()
-  )
-
-  res <- fp(
+  res <- .fotmob_get_single_season_stats(
     league_id = league_id,
     season_id = filt_season_options$season_id,
     stat = stat

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -16,7 +16,7 @@
     stat
   )
 
-  resp <- safely_from_json(url)
+  resp <- safely_get_content(url)
   if(!is.null(resp$error)) {
     warning(
       sprintf(
@@ -166,7 +166,7 @@
         filter(.data[["Name"]] == !!season)
 
       topstats_url <- sprintf("https://data.fotmob.com/%s", link$RelativePath)
-      topstats <- purrr::map_dfr(topstats_url, safely_from_json) ## Liga MX will have two rows
+      topstats <- purrr::map_dfr(topstats_url, safely_get_content) ## Liga MX will have two rows
       toplists <- topstats$result$TopLists %>%
         dplyr::distinct(header = .data[["Title"]], name = .data[["StatName"]])
 

--- a/R/internals.R
+++ b/R/internals.R
@@ -268,6 +268,7 @@
 #'
 #' @importFrom magrittr %>%
 #' @importFrom httr GET set_cookies content
+#' @importFrom jsonlite fromJSON
 #' @noRd
 #'
 .get_clean_understat_json <- function(page_url, script_name) {
@@ -280,7 +281,7 @@
     clean_json <- clean_json[grep(script_name, clean_json)] %>% stringi::stri_unescape_unicode()
     clean_json <- qdapRegex::rm_square(clean_json, extract = TRUE, include.markers = TRUE) %>% unlist() %>% stringr::str_subset("\\[\\]", negate = TRUE)
 
-    out_df <- lapply(clean_json, .fromJSON) %>% do.call("rbind", .)
+    out_df <- lapply(clean_json, jsonlite::fromJSON) %>% do.call("rbind", .)
     # some outputs don't come with the season present, so add it in if not
     if(!any(grepl("season", colnames(out_df)))) {
       season_element <- page %>% rvest::html_nodes(xpath = '//*[@name="season"]') %>%
@@ -409,40 +410,6 @@
   ua <- httr::user_agent(agent)
   session <- rvest::session(url = page_url, ua)
   xml2::read_html(session)
-}
-
-# Use 1.8.0 version of jsonlite::fromJSON since 1.8.2's version (that uses base::url()) doesn't work for some cases
-#' @importFrom jsonlite validate parse_json
-#' @importFrom curl new_handle handle_setheaders curl
-.fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector, simplifyMatrix = simplifyVector, flatten = FALSE, ...) {
-
-  # check type
-  if (!is.character(txt) && !inherits(txt, "connection")) {
-    stop("Argument 'txt' must be a JSON string, URL or file.")
-  }
-
-  # overload for URL or path
-  if (is.character(txt) && length(txt) == 1 && nchar(txt, type="bytes") < 2084 && !jsonlite::validate(txt)) {
-    if (grepl("^https?://", txt, useBytes=TRUE)) {
-      agent <- getOption("worldfootballR.agent", default = "RStudio Desktop (2022.7.1.554); R (4.1.1 x86_64-w64-mingw32 x86_64 mingw32)")
-      h <- curl::new_handle(useragent = agent)
-      curl::handle_setheaders(h, Accept = "application/json, text/*, */*")
-      txt <- curl::curl(txt, handle = h)
-    } else if (file.exists(txt)) {
-      # With files we can never know for sure the encoding. Lets try UTF8 first.
-      # txt <- raw_to_json(readBin(txt, raw(), file.info(txt)$size));
-      txt <- file(txt)
-    }
-  }
-
-  jsonlite::parse_json(
-    txt = txt,
-    flatten = flatten,
-    simplifyVector = simplifyVector,
-    simplifyDataFrame = simplifyDataFrame,
-    simplifyMatrix = simplifyMatrix,
-    ...
-  )
 }
 
 #' @importFrom httr GET content

--- a/R/internals.R
+++ b/R/internals.R
@@ -445,16 +445,14 @@
   )
 }
 
-# Sometimes .fromJSON doesn't work, but jsonlite::fromJSON will. See https://github.com/JaseZiv/worldfootballR/issues/201
-#' @importFrom purrr safely
+#' @importFrom httr GET content
 #' @importFrom jsonlite fromJSON
-#'
 #' @noRd
-safely_from_json <- function(...) {
-  f <- purrr::safely(.fromJSON, otherwise = NULL, quiet = TRUE)
-  resp <- f(...)
-  if (!is.null(resp)) {
-    return(resp)
-  }
-  jsonlite::fromJSON(...)
+get_content <- function(url) {
+  resp <- httr::GET(url)
+  cont <- httr::content(resp, as = "text")
+  jsonlite::fromJSON(cont)
 }
+
+#' @importFrom purrr safely
+safely_get_content <- purrr::safely(get_content, otherwise = NULL, quiet = TRUE)

--- a/R/internals.R
+++ b/R/internals.R
@@ -450,7 +450,8 @@
 #' @noRd
 get_content <- function(url) {
   resp <- httr::GET(url)
-  cont <- httr::content(resp, as = "text")
+  ## suppress encoding messages
+  suppressMessages(cont <- httr::content(resp, as = "text"))
   jsonlite::fromJSON(cont)
 }
 

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -225,7 +225,7 @@ test_that("fotmob_get_league_tables() works", {
 test_that("fotmob_get_season_stats() works", {
   testthat::skip_on_cran()
 
-  expected_team_stat_cols <- c("country", "league_name", "league_id", "season_name", "season_id", "stat_league_name", "stat_name", "stat", "participant_name", "particiant_id", "team_id", "team_color", "stat_value", "sub_stat_value", "minutes_played", "matches_played", "stat_value_count", "rank", "participant_country_code")
+  expected_stat_cols <- c("country", "league_name", "league_id", "season_name", "season_id", "stat_league_name", "stat_name", "stat", "participant_name", "particiant_id", "team_id", "team_color", "stat_value", "sub_stat_value", "minutes_played", "matches_played", "stat_value_count", "rank", "participant_country_code", "team_name")
   epl_team_xg_21_a <- fotmob_get_season_stats(
     league_id = 47,
     season_name = "2020/2021",
@@ -233,7 +233,7 @@ test_that("fotmob_get_season_stats() works", {
     team_or_player = "team"
   )
   expect_gt(nrow(epl_team_xg_21_a), 0)
-  expect_setequal(colnames(epl_team_xg_21_a), expected_team_stat_cols)
+  expect_setequal(colnames(epl_team_xg_21_a), expected_stat_cols)
 
   get_epl_season_stats <- function(
     season_name = "2020/2021",
@@ -262,14 +262,13 @@ test_that("fotmob_get_season_stats() works", {
     team_or_player = "team"
   )
   expect_gt(nrow(liga_mx_team_xg_21), 0)
-  expect_setequal(colnames(liga_mx_team_xg_21), expected_team_stat_cols)
+  expect_setequal(colnames(liga_mx_team_xg_21), expected_stat_cols)
 
   ## fotmob has data for 2016/2017 for some leagues and stats, but not all
-  expect_warning(
+  expect_error(
     get_epl_season_stats(
       season_name = "2016/2017"
-    ),
-    regexp = "Issue with data"
+    )
   )
 
   ## fotmob doesn't have data this far back for any stat or league
@@ -280,7 +279,6 @@ test_that("fotmob_get_season_stats() works", {
     regexp = "not found"
   )
 
-  expected_player_stat_cols <- c(expected_team_stat_cols, "team_name")
   epl_player_xg_21 <- get_epl_season_stats(
     team_or_player = "player"
   )
@@ -288,16 +286,15 @@ test_that("fotmob_get_season_stats() works", {
   expect_setequal(colnames(epl_player_xg_21), expected_stat_cols)
 
   ## similar to team test
-  expect_warning(
+  expect_error(
     get_epl_season_stats(
       season = "2016/2017",
       team_or_player = "player"
-    ),
-    regexp = "Issue with data"
+    )
   )
 
   ## similar to team test
-  expect_message(
+  expect_error(
     get_epl_season_stats(
       season = "2010/2011",
       team_or_player = "player"
@@ -309,7 +306,8 @@ test_that("fotmob_get_season_stats() works", {
   expect_error(
     get_epl_season_stats(
       team_or_player = c("team", "player")
-    )
+    ),
+    regexp = "one of either"
   )
 
   ## invalid `stat_name`
@@ -423,22 +421,22 @@ test_that("fotmob_get_match_details() works", {
   testthat::skip_on_cran()
 
   expected_match_detail_nonshot_cols <- c("match_id", "match_round", "league_id", "league_name", "league_round_name", "parent_league_id", "parent_league_season", "match_time_utc", "home_team_id", "home_team", "home_team_color", "away_team_id", "away_team", "away_team_color")
-  expected_match_detail_shot_cols <- c("id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio", "first_name", "last_name", "team_color")
+  expected_match_detail_shot_cols <- c("id", "event_type", "team_id", "player_id", "player_name", "x", "y", "min", "min_added", "is_blocked", "is_on_target", "blocked_x", "blocked_y", "goal_crossed_y", "goal_crossed_z", "expected_goals", "expected_goals_on_target", "shot_type", "situation", "period", "is_own_goal", "on_goal_shot_x", "on_goal_shot_y", "on_goal_shot_zoom_ratio")
   expected_match_detail_cols <- c(expected_match_detail_nonshot_cols, expected_match_detail_shot_cols)
   details <- fotmob_get_match_details(c(3609987, 3609979))
 
   expect_gt(nrow(details), 0)
-  expect_setequal(colnames(details), expected_match_detail_cols)
+  expect_true(all(expected_match_detail_cols %in% colnames(details)))
 
   ## non-domestic match
   details <- fotmob_get_match_details(3846342)
   expect_gt(nrow(details), 0)
-  expect_setequal(colnames(details), expected_match_detail_cols)
+  expect_true(all(expected_match_detail_cols %in% colnames(details)))
 
   ## match with no shots
   details <- fotmob_get_match_details(3361745)
   expect_equal(nrow(details), 1)
-  expect_setequal(colnames(details), expected_match_detail_nonshot_cols)
+  expect_true(expected_match_detail_nonshot_cols %in% colnames(details))
 })
 
 test_that("fotmob_get_match_players() works", {

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -225,7 +225,7 @@ test_that("fotmob_get_league_tables() works", {
 test_that("fotmob_get_season_stats() works", {
   testthat::skip_on_cran()
 
-  expected_stat_cols <- c("country", "league_name", "league_id", "season_name", "season_id", "stat_league_name", "stat_name", "stat", "participant_name", "particiant_id", "team_id", "team_color", "stat_value", "sub_stat_value", "minutes_played", "matches_played", "stat_value_count", "rank", "participant_country_code", "team_name")
+  expected_team_stat_cols <- c("country", "league_name", "league_id", "season_name", "season_id", "stat_league_name", "stat_name", "stat", "participant_name", "particiant_id", "team_id", "team_color", "stat_value", "sub_stat_value", "minutes_played", "matches_played", "stat_value_count", "rank", "participant_country_code")
   epl_team_xg_21_a <- fotmob_get_season_stats(
     league_id = 47,
     season_name = "2020/2021",
@@ -233,7 +233,7 @@ test_that("fotmob_get_season_stats() works", {
     team_or_player = "team"
   )
   expect_gt(nrow(epl_team_xg_21_a), 0)
-  expect_setequal(colnames(epl_team_xg_21_a), expected_stat_cols)
+  expect_setequal(colnames(epl_team_xg_21_a), expected_team_stat_cols)
 
   get_epl_season_stats <- function(
     season_name = "2020/2021",
@@ -262,7 +262,7 @@ test_that("fotmob_get_season_stats() works", {
     team_or_player = "team"
   )
   expect_gt(nrow(liga_mx_team_xg_21), 0)
-  expect_setequal(colnames(liga_mx_team_xg_21), expected_stat_cols)
+  expect_setequal(colnames(liga_mx_team_xg_21), expected_team_stat_cols)
 
   ## fotmob has data for 2016/2017 for some leagues and stats, but not all
   expect_warning(
@@ -280,6 +280,7 @@ test_that("fotmob_get_season_stats() works", {
     regexp = "not found"
   )
 
+  expected_player_stat_cols <- c(expected_team_stat_cols, "team_name")
   epl_player_xg_21 <- get_epl_season_stats(
     team_or_player = "player"
   )

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -272,7 +272,7 @@ test_that("fotmob_get_season_stats() works", {
   )
 
   ## fotmob doesn't have data this far back for any stat or league
-  expect_message(
+  expect_error(
     get_epl_season_stats(
       season_name = "2010/2011"
     ),
@@ -436,7 +436,7 @@ test_that("fotmob_get_match_details() works", {
   ## match with no shots
   details <- fotmob_get_match_details(3361745)
   expect_equal(nrow(details), 1)
-  expect_true(expected_match_detail_nonshot_cols %in% colnames(details))
+  expect_true(all(expected_match_detail_nonshot_cols %in% colnames(details)))
 })
 
 test_that("fotmob_get_match_players() works", {


### PR DESCRIPTION
`jsonlite::JSON({raw URL})` doesn't seem to work anymore on Fotmob. A solution is to use `httr::GET() %>% httr::content(as = "text") %>% jsonlite::fromJSON()`.

Addresses https://github.com/JaseZiv/worldfootballR/issues/261, https://github.com/JaseZiv/worldfootballR/issues/262, https://github.com/JaseZiv/worldfootballR/issues/264

In addition:
- Updated some unused internals for `fotmob_get_season_stats()`
- Return errors instead of warnings in `fotmob_get_season_stats()`
- Reduced strictness of some Fotmob tests (checks for exact equality of columns) since Fotmob seems to occassionally add or remove fields
- Removed all traces of `.fromJSON()`, which was a temporary hack for when `fromJSON()` didn't work on some URLs. Now that we're not using `fromJSON()` on raw Fotmob URLs at all, we can get rid of that function
