### PR TITLE
Fix fotmob team color in `fotmob_get_match_details()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0000
+Version: 0.6.3.0001
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # worldfootballR (development version)
 
+### Bugs
+
+* `fotmob_get_match_details()` failing due to change in `teamColors` JSON element (0.6.2.3001) [#271](https://github.com/JaseZiv/worldfootballR/issues/271)
+
+# worldfootballR 0.6.3
+
 ### Breaking Changes
 
 * `tm_player_transfer_history()` now contains an additional column in the returned dataframe (`transfer_type`). This column differentiate between regular transfers, free transfers, loans and paid loans and transfers due to players returning from loan.
@@ -8,7 +14,7 @@
 ### Bugs
 
 * `fotmob_get_match_players()` was failing for upcoming matches due to a missing `stats` column (0.6.2.1000) [#226](https://github.com/JaseZiv/worldfootballR/issues/226)
-* `tm_team_transfer_balances()` failing because of empty team boxes being collected (0.6.2.1000) [228](https://github.com/JaseZiv/worldfootballR/issues/228)
+* `tm_team_transfer_balances()` failing because of empty team boxes being collected (0.6.2.1000) [#228](https://github.com/JaseZiv/worldfootballR/issues/228)
 * `fotmob_get_league_matches()` was failing due to an extra `purrr::map_dfr` that is no longer needed (0.6.2.2000) [#229](https://github.com/JaseZiv/worldfootballR/issues/229)
 * All understat functions were failing due to a new cookie requirement (0.6.2.5000) [#239](https://github.com/JaseZiv/worldfootballR/issues/239)
 * `fb_player_scouting_report()` failing due to HTML changes on FBRef (0.6.2.7000) [#242](https://github.com/JaseZiv/worldfootballR/issues/242)

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -12,14 +12,15 @@
     parent_league_season = general$parentLeagueSeason,
     match_time_utc = general$matchTimeUTC
   )
+  colors <- general$teamColor
   teams <- data.frame(
     stringsAsFactors = FALSE,
     home_team_id = unlist(general$homeTeam$id),
     home_team = unlist(general$homeTeam$name),
-    home_team_color = unlist(general$teamColors$home),
+    home_team_color = colors[1, "color"],
     away_team_id = unlist(general$awayTeam$id),
     away_team = unlist(general$awayTeam$name),
-    away_team_color = unlist(general$teamColors$away)
+    away_team_color = colors[2, "color"]
   )
   list(
     resp = resp,

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -409,12 +409,12 @@ test_that("fotmob_get_match_team_stats() works", {
   match_team_stats <- fotmob_get_match_team_stats(c(3609987, 3609979))
 
   expect_gt(nrow(match_team_stats), 0)
-  expect_setequal(colnames(match_team_stats), expected_match_team_stats_cols)
+  expect_true(all(expected_match_team_stats_cols %in% colnames(match_team_stats)))
 
   ## non-domestic match
   match_team_stats <- fotmob_get_match_team_stats(3846342)
   expect_gt(nrow(match_team_stats), 0)
-  expect_setequal(colnames(match_team_stats), expected_match_team_stats_cols)
+  expect_true(all(expected_match_team_stats_cols %in% colnames(match_team_stats)))
 })
 
 test_that("fotmob_get_match_details() works", {

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -156,11 +156,11 @@ test_that("load_fotmob_match_details() works", {
   expect_type(epl_match_details, "list")
   n_rows_epl_match_details <- nrow(epl_match_details)
   expect_gt(n_rows_epl_match_details, 0)
-  expect_equal(sort(colnames(epl_match_details)), sort(expected_match_detail_cols))
+  expect_true(all(expected_match_detail_cols %in% colnames(epl_match_details)))
 
   epl_ll_match_details <- load_fotmob_match_details(league_id = c(47, 87))
   expect_gt(nrow(epl_ll_match_details), n_rows_epl_match_details)
-  expect_equal(sort(colnames(epl_ll_match_details)), sort(expected_match_detail_cols))
+  expect_true(all(expected_match_detail_cols %in% colnames(epl_ll_match_details)))
 
   expect_error(load_fotmob_match_details(league_id = 0))
 })


### PR DESCRIPTION
Fotmob slightly changed the format of the JSON for match details. Specifically, they provide 4 colors per team now. I'm just plucking out the first `color`.

![image](https://user-images.githubusercontent.com/15663460/233215008-25c17c20-9c56-4d05-8509-65d01264c5be.png)


Fixes #271.