### PR TITLE
Fix fb home away tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0005
+Version: 0.6.3.0006
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * `fotmob_get_league_ids()` failing due to addition of `localizedName` JSON element (0.6.3.0003) [#275](https://github.com/JaseZiv/worldfootballR/issues/275)
 * `fotmob_get_match_details()` failing (again) due to change in `teamColors` JSON element (0.6.3.0003)
 * `fotmob_get_match_players()` failing due to addition of nested JSON elements in `stat` element (0.6.3.0004) [#277](https://github.com/JaseZiv/worldfootballR/issues/277)
-
+* `fb_season_team_stats()` failing to get the correct home/away league table on some unusual layout league pages (0.6.3.0006) [#282](https://github.com/JaseZiv/worldfootballR/issues/282)
 
 ### Improvements
 

--- a/R/get_season_team_stats.R
+++ b/R/get_season_team_stats.R
@@ -62,6 +62,17 @@ fb_season_team_stats <- function(country, gender, season_end_year, tier, stat_ty
 
     season_stats_page <- .load_page(season_url)
 
+    # have included this to differentiate between how different leagues handle ladders/tables
+    league_tables <- season_stats_page %>% rvest::html_nodes("#content .table_wrapper") %>% rvest::html_elements("h2") %>% rvest::html_text()
+
+    # we either want to detect the presence of League Table or Regular season and get the index of that to be able to extractg the table we want
+    if(length(grep("league table", tolower(league_tables))) > 0) {
+      league_tables_idx <- grep("league table", tolower(league_tables))
+    } else {
+      league_tables_idx <- grep("^Regular season", league_tables)
+    }
+
+
     league_standings <- season_stats_page %>% rvest::html_nodes("table")
 
     all_stat_tabs_holder <- season_stats_page %>% rvest::html_nodes(".stats_table")
@@ -88,7 +99,8 @@ fb_season_team_stats <- function(country, gender, season_end_year, tier, stat_ty
 
           stat_df <- dplyr::bind_rows(stat_df1, stat_df2)
         } else {
-          stat_df <- league_standings[1] %>% rvest::html_table() %>% data.frame()
+          # the first (min()) table with the header League Table or Regular Season is the overall table:
+          stat_df <- league_standings[min(league_tables_idx)] %>% rvest::html_table() %>% data.frame()
         }
 
         if(any(grepl("Attendance", names(stat_df)))) {

--- a/R/get_season_team_stats.R
+++ b/R/get_season_team_stats.R
@@ -111,7 +111,7 @@ fb_season_team_stats <- function(country, gender, season_end_year, tier, stat_ty
           stat_df <- dplyr::bind_rows(stat_df1, stat_df2)
           stat_df$Conference[1] <- "Conference"
         } else {
-          stat_df <- league_standings[2] %>% rvest::html_table() %>% data.frame()
+          stat_df <- league_standings[grepl("home_away",all_tables)] %>% rvest::html_table() %>% data.frame()
         }
 
         var_names <- stat_df[1,] %>% as.character()

--- a/man/fotmob_get_league_tables.Rd
+++ b/man/fotmob_get_league_tables.Rd
@@ -27,7 +27,7 @@ fotmob_get_league_tables(
 returns a dataframe of league standings
 }
 \description{
-Returns league standings from fotmob.com. 3 types are returned: all, home, away
+Returns league standings from fotmob.com. 4 types are returned: all, home, away, form
 }
 \examples{
 \donttest{


### PR DESCRIPTION
#282

The "league_table_home_away" part now filters the "home_away" table even if it isn't the second table in the list.

Doing the same for the "league_table" argument by searching for the "overall" string isn't as simple... there can be several tables with "overall", see below for [Liga MX 2019-20](https://fbref.com/en/comps/31/2019-2020/).

It could be hard-coded in the same way that MLS is (in the if statements with "Conference"), or some other method to identify the right "overall" league table more robustly.

![home_away_overall](https://github.com/JaseZiv/worldfootballR/assets/52595717/3a044e58-3194-4298-ac99-444f11c88327)
