### PR TITLE
Fix `fotmob_get_match_players()` list-col type bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0006
+Version: 0.6.3.0007
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,10 +7,11 @@
 * `fotmob_get_match_details()` failing (again) due to change in `teamColors` JSON element (0.6.3.0003)
 * `fotmob_get_match_players()` failing due to addition of nested JSON elements in `stat` element (0.6.3.0004) [#277](https://github.com/JaseZiv/worldfootballR/issues/277)
 * `fb_season_team_stats()` failing to get the correct home/away league table on some unusual layout league pages (0.6.3.0006) [#282](https://github.com/JaseZiv/worldfootballR/issues/282)
+* `fotmob_get_match_players()` failing due mismatch in `list` and `data.frame` types for internal `stats` column before unnesting (0.6.3.0007) [#291](https://github.com/JaseZiv/worldfootballR/issues/291)
 
 ### Improvements
 
-* `fotmob_get_match_momentum()` added (0.6.2.3002)
+* `fotmob_get_match_momentum()` added (0.6.2.0002)
 * `fotmob_get_league_tables()` returns form table (0.6.3.0005) [#279](https://github.com/JaseZiv/worldfootballR/issues/279)
 
 ***

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -74,9 +74,8 @@
   n <- length(player_ids)
   ## for some reason jsonlite tries to combine stuff row-wise when it really should just bind things column-wise
   ps <- p[["stats"]]
-
   stats <- if(is.null(ps)) {
-    list(NULL)
+    NULL
   } else {
 
     pss <- purrr::map_dfr(ps, .clean_stats)
@@ -114,7 +113,7 @@
     "away_team_id" = .ppi(p, "teamData", "away", "id", n = n),
     "away_team_color" = .ppc(p, "teamData", "away", "color", n = n)
   )
-  rows$stats <- stats
+  rows$stats <- list(stats)
   rows$shotmap <- if(!is.null(.pp2(p, "shotmap", 1))) .pp2(p, "shotmap") else NULL
   rows
 }

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -203,10 +203,7 @@ test_that("fotmob_get_league_tables() works", {
   expect_table_cols(epl_ll_league_tables, expected_domestic_league_table_cols)
 
   table_types <- dplyr::distinct(epl_ll_league_tables, table_type)
-  expect_equal(
-    table_types$table_type,
-    c("all", "home", "away", "form")
-  )
+  expect_true(all(c("all", "home", "away") %in% table_types$table_type))
 
   ## non-domestic league
   ## Can only check on CL after group stages and briefly after the final.
@@ -474,6 +471,12 @@ test_that("fotmob_get_match_players() works", {
 
   ## non-domestic league
   players <- fotmob_get_match_players(3846347)
+  expect_gt(nrow(players), 0)
+  expect_expected_match_player_cols(players)
+
+  ## Does it work with a game with some players missing stats?
+  ##   https://www.fotmob.com/match/2999754/matchfacts/vasco-da-gama-vs-atletico-mg
+  players <- fotmob_get_match_players(2999754)
   expect_gt(nrow(players), 0)
   expect_expected_match_player_cols(players)
 })

--- a/tests/testthat/test-fotmob.R
+++ b/tests/testthat/test-fotmob.R
@@ -478,7 +478,6 @@ test_that("fotmob_get_match_players() works", {
   ##   https://www.fotmob.com/match/2999754/matchfacts/vasco-da-gama-vs-atletico-mg
   players <- fotmob_get_match_players(2999754)
   expect_gt(nrow(players), 0)
-  expect_expected_match_player_cols(players)
 })
 
 


### PR DESCRIPTION
Fixes a bug where there was a mismatch in the types for the (internal) `stat` column before unnesting in `fotmob_get_match_players()`.

Fixes #291.

```r
nrow(fotmob_get_match_players(2999748))
#> 43
```