### PR TITLE
Fix `fotmob_get_match_stats()` bug due to additional nesting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0007
+Version: 0.6.3.0008
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * `fotmob_get_match_players()` failing due to addition of nested JSON elements in `stat` element (0.6.3.0004) [#277](https://github.com/JaseZiv/worldfootballR/issues/277)
 * `fb_season_team_stats()` failing to get the correct home/away league table on some unusual layout league pages (0.6.3.0006) [#282](https://github.com/JaseZiv/worldfootballR/issues/282)
 * `fotmob_get_match_players()` failing due mismatch in `list` and `data.frame` types for internal `stats` column before unnesting (0.6.3.0007) [#291](https://github.com/JaseZiv/worldfootballR/issues/291)
+* `fotmob_get_match_stats()` failing due to Fotmob additional nesting (0.6.3.0008 [#295](https://github.com/JaseZiv/worldfootballR/issues/295)
 
 ### Improvements
 

--- a/R/fotmob_matches.R
+++ b/R/fotmob_matches.R
@@ -227,7 +227,7 @@ fotmob_get_match_team_stats <- function(match_ids) {
       general$teams
     )
 
-    stats <- general$resp$content$stats$stats %>% janitor::clean_names()
+    stats <- janitor::clean_names(general$resp$content$stats$Periods$All$stats)
     has_stats <- length(stats) > 0
     df <- tibble::as_tibble(df)
     if(isTRUE(has_stats)) {


### PR DESCRIPTION
Fotmob added additional nesting for match stats (`Periods/All/`)

![image](https://github.com/JaseZiv/worldfootballR/assets/15663460/c7d55816-84c6-4582-a3d5-565b5f67ab70)

Fixes #295 
