### PR TITLE
Eliminate `fotmob_get_match_stats()` error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0008
+Version: 0.6.3.0009
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,13 @@
 * `fotmob_get_match_players()` failing due to addition of nested JSON elements in `stat` element (0.6.3.0004) [#277](https://github.com/JaseZiv/worldfootballR/issues/277)
 * `fb_season_team_stats()` failing to get the correct home/away league table on some unusual layout league pages (0.6.3.0006) [#282](https://github.com/JaseZiv/worldfootballR/issues/282)
 * `fotmob_get_match_players()` failing due mismatch in `list` and `data.frame` types for internal `stats` column before unnesting (0.6.3.0007) [#291](https://github.com/JaseZiv/worldfootballR/issues/291)
-* `fotmob_get_match_stats()` failing due to Fotmob additional nesting (0.6.3.0008 [#295](https://github.com/JaseZiv/worldfootballR/issues/295)
+* `fotmob_get_match_stats()` failing due to Fotmob additional nesting (0.6.3.0008) [#295](https://github.com/JaseZiv/worldfootballR/issues/295)
 
 ### Improvements
 
 * `fotmob_get_match_momentum()` added (0.6.2.0002)
 * `fotmob_get_league_tables()` returns form table (0.6.3.0005) [#279](https://github.com/JaseZiv/worldfootballR/issues/279)
+* `fotmob_get_match_stats()`: suppress error messages for seasons without data (0.6.3.0009) [#297](https://github.com/JaseZiv/worldfootballR/issues/297)
 
 ***
 

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -105,6 +105,10 @@
     topstats_url <- sprintf("https://data.fotmob.com/%s", link$RelativePath)
     topstats <- purrr::map_dfr(topstats_url, safely_get_content) ## Liga MX will have two rows
 
+    if (length(topstats$result$TopLists) == 0) {
+      return(data.frame())
+    }
+
     toplists <- topstats$result$TopLists %>%
       dplyr::distinct(header = .data[["Title"]], name = .data[["StatName"]])
 
@@ -142,7 +146,7 @@
   possibly_extract_options <- purrr::possibly(
     extract_options,
     otherwise = tibble::tibble(),
-    quiet = TRUE
+    quiet = FALSE
   )
 
   valid_seasons %>%

--- a/R/fotmob_stats.R
+++ b/R/fotmob_stats.R
@@ -104,6 +104,7 @@
 
     topstats_url <- sprintf("https://data.fotmob.com/%s", link$RelativePath)
     topstats <- purrr::map_dfr(topstats_url, safely_get_content) ## Liga MX will have two rows
+
     toplists <- topstats$result$TopLists %>%
       dplyr::distinct(header = .data[["Title"]], name = .data[["StatName"]])
 
@@ -141,7 +142,7 @@
   possibly_extract_options <- purrr::possibly(
     extract_options,
     otherwise = tibble::tibble(),
-    quiet = FALSE
+    quiet = TRUE
   )
 
   valid_seasons %>%


### PR DESCRIPTION
The function was printing out `Error: no applicable method for 'distinct' applied to an object of class "list"` due to attempting to scrape data for 2023/24, since the season option is shown in the menu, but there is no data yet for it. One solution could be to set `quiet = TRUE` in the `possibly()` function that wraps the helper function that does scraping, but I like to see people report issues for subtle things like this. The solution I've implemented is a "short-cut" exit from the scraper when no data is detected.

Fixes #297.