### PR TITLE
Bug fixes for `fotmob_get_match_players()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.3.0010
+Version: 0.6.3.0011
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * `fotmob_get_match_players()` failing due mismatch in `list` and `data.frame` types for internal `stats` column before unnesting (0.6.3.0007) [#291](https://github.com/JaseZiv/worldfootballR/issues/291)
 * `fotmob_get_match_stats()` failing due to Fotmob additional nesting (0.6.3.0008) [#295](https://github.com/JaseZiv/worldfootballR/issues/295)
 * `fotmob_get_match_players()` returning nested list elements for `stat` columns (0.6.3.0010) [#298](https://github.com/JaseZiv/worldfootballR/issues/298)
+* `fotmob_get_match_players()` returning repeated stats and failing for NULL case (0.6.3.0011) [#298](https://github.com/JaseZiv/worldfootballR/issues/298)
 
 ### Improvements
 

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -73,7 +73,8 @@
   n <- length(player_ids)
   ## for some reason jsonlite tries to combine stuff row-wise when it really should just bind things column-wise
   ps <- p[["stats"]]
-  stats <- if(is.null(ps)) {
+  does_not_have_stats <- is.null(ps)
+  stats <- if (does_not_have_stats) {
     NULL
   } else {
 
@@ -114,9 +115,13 @@
     "away_team_color" = .ppc(p, "teamData", "away", "color", n = n)
   )
 
-  rows$stats <- vector(mode = "list", length = nrow(stats))
-  for (i in 1:nrow(rows)) {
-    rows[i, ]$stats <- list(stats[1, ])
+  if (does_not_have_stats) {
+    rows$stats <- list(NULL)
+  } else {
+    rows$stats <- vector(mode = "list", length = nrow(stats))
+    for (i in 1:nrow(rows)) {
+      rows[i, ]$stats <- list(stats[i, ])
+    }
   }
 
   rows$shotmap <- if(!is.null(.pp2(p, "shotmap", 1))) .pp2(p, "shotmap") else NULL

--- a/R/fotmob_players.R
+++ b/R/fotmob_players.R
@@ -116,7 +116,7 @@
   )
 
   if (does_not_have_stats) {
-    rows$stats <- list(NULL)
+    rows$stats <- list(stats)
   } else {
     rows$stats <- vector(mode = "list", length = nrow(stats))
     for (i in 1:nrow(rows)) {


### PR DESCRIPTION
Bug fixes for `fotmob_get_match_players()`

1. Remove hard-coded by-row assignment in `fotmob_get_match_players()` (fixes #298)
2. Fix failure in cases where players do not have stats (observed in [recent R CMD check](https://github.com/JaseZiv/worldfootballR/actions/runs/5570217380/job/15082665666))