### PR TITLE
Fix for fb_league_stats() regarding non-dom-leagues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.4.0002
+Version: 0.6.4.0003
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ### Improvements
 * `fb_player_season_stats()` now includes the ability to get a player's national team stats [https://github.com/JaseZiv/worldfootballR/pull/310/files] (0.6.4.0002)
+* `fb_league_stats()` now correctly scrapes non domestic competitions [https://github.com/JaseZiv/worldfootballR/pull/325] (0.6.4.0003)
 
 
 ***

--- a/R/fb_league_stats.R
+++ b/R/fb_league_stats.R
@@ -151,23 +151,32 @@ fb_league_stats <- function(
 
   seasons <- read.csv("https://raw.githubusercontent.com/JaseZiv/worldfootballR_data/master/raw-data/all_leages_and_cups/all_competitions.csv", stringsAsFactors = F)
 
-  league_urls <- seasons %>%
-    dplyr::filter(
-      stringr::str_detect(.data[["competition_type"]], "Leagues"),
-      .data[["country"]] %in% .env[["country"]],
-      .data[["gender"]]  %in% .env[["gender"]],
-      .data[["season_end_year"]] %in% .env[["season_end_year"]],
-      .data[["tier"]] %in% .env[["tier"]]
-    ) %>%
-    dplyr::pull(.data[["seasons_urls"]]) %>%
-    unique()
+  if(is.na(non_dom_league_url)) {
+    seasons_urls <- seasons %>%
+      dplyr::filter(stringr::str_detect(.data[["competition_type"]], "Leagues")) %>%
+      dplyr::filter(country %in% .env[["country"]],
+                    gender %in% .env[["gender"]],
+                    season_end_year %in% .env[["season_end_year"]],
+                    tier %in% .env[["tier"]],
+                    !is.na(.data[["seasons_urls"]])) %>%
+      dplyr::arrange(.env[["season_end_year"]]) %>%
+      dplyr::pull(.data[["seasons_urls"]]) %>% unique()
+  } else {
+    seasons_urls <- seasons %>%
+      dplyr::filter(.data[["comp_url"]] %in% .env[["non_dom_league_url"]],
+                    gender %in% .env[["gender"]],
+                    season_end_year %in% .env[["season_end_year"]],
+                    !is.na(.data[["seasons_urls"]])) %>%
+      dplyr::arrange(.env[["season_end_year"]]) %>%
+      dplyr::pull(.data[["seasons_urls"]]) %>% unique()
+  }
 
-  if (length(league_urls) == 0) {
+  if (length(seasons_urls) == 0) {
     stop("Could not find any URLs matching input parameters")
   }
 
   urls <- tidyr::crossing(
-    "league_url" = league_urls,
+    "league_url" = seasons_urls,
     "stat_type" = dplyr::case_when(
       stat_type == "standard" ~ "stats",
       stat_type == "keepers_adv" ~ "keepersadv",

--- a/R/fb_league_stats.R
+++ b/R/fb_league_stats.R
@@ -159,7 +159,7 @@ fb_league_stats <- function(
                     season_end_year %in% .env[["season_end_year"]],
                     tier %in% .env[["tier"]],
                     !is.na(.data[["seasons_urls"]])) %>%
-      dplyr::arrange(.env[["season_end_year"]]) %>%
+      # dplyr::arrange(.env[["season_end_year"]]) %>%
       dplyr::pull(.data[["seasons_urls"]]) %>% unique()
   } else {
     seasons_urls <- seasons %>%
@@ -167,7 +167,7 @@ fb_league_stats <- function(
                     gender %in% .env[["gender"]],
                     season_end_year %in% .env[["season_end_year"]],
                     !is.na(.data[["seasons_urls"]])) %>%
-      dplyr::arrange(.env[["season_end_year"]]) %>%
+      # dplyr::arrange(.env[["season_end_year"]]) %>%
       dplyr::pull(.data[["seasons_urls"]]) %>% unique()
   }
 

--- a/R/fb_league_stats.R
+++ b/R/fb_league_stats.R
@@ -108,6 +108,17 @@
 #'   stat_type = "shooting",
 #'   team_or_player = "player"
 #' )
+#' ## Non-domestic league
+#' ##   Note that this is more likely to fail due to the volume of players
+#' fb_league_stats(
+#'   country = NA_character_,
+#'   gender = "M",
+#'   season_end_year = 2023,
+#'   tier = NA_character_,
+#'   non_dom_league_url = "https://fbref.com/en/comps/8/history/Champions-League-Seasons",
+#'   stat_type = "standard",
+#'   team_or_player = "player"
+#' )
 #' })
 #' }
 fb_league_stats <- function(
@@ -151,29 +162,29 @@ fb_league_stats <- function(
 
   seasons <- read.csv("https://raw.githubusercontent.com/JaseZiv/worldfootballR_data/master/raw-data/all_leages_and_cups/all_competitions.csv", stringsAsFactors = F)
 
-  if(is.na(non_dom_league_url)) {
-    seasons_urls <- seasons %>%
-      dplyr::filter(stringr::str_detect(.data[["competition_type"]], "Leagues")) %>%
-      dplyr::filter(country %in% .env[["country"]],
-                    gender %in% .env[["gender"]],
-                    season_end_year %in% .env[["season_end_year"]],
-                    tier %in% .env[["tier"]],
-                    !is.na(.data[["seasons_urls"]])) %>%
-      # dplyr::arrange(.env[["season_end_year"]]) %>%
-      dplyr::pull(.data[["seasons_urls"]]) %>% unique()
+  seasons_urls <- seasons %>%
+    dplyr::filter(
+      .data[["country"]] %in% .env[["country"]],
+      .data[["gender"]]  %in% .env[["gender"]],
+      .data[["season_end_year"]] %in% .env[["season_end_year"]],
+      .data[["tier"]] %in% .env[["tier"]]
+    )
+
+  seasons_urls <- if (is.na(non_dom_league_url)) {
+    seasons_urls %>%
+      dplyr::filter(
+        stringr::str_detect(.data[["competition_type"]], "Leagues")
+      )
   } else {
-    seasons_urls <- seasons %>%
-      dplyr::filter(.data[["comp_url"]] %in% .env[["non_dom_league_url"]],
-                    gender %in% .env[["gender"]],
-                    season_end_year %in% .env[["season_end_year"]],
-                    !is.na(.data[["seasons_urls"]])) %>%
-      # dplyr::arrange(.env[["season_end_year"]]) %>%
-      dplyr::pull(.data[["seasons_urls"]]) %>% unique()
+    seasons_urls %>%
+      dplyr::filter(
+        .data[["comp_url"]] %in% .env[["non_dom_league_url"]]
+      )
   }
 
-  if (length(seasons_urls) == 0) {
-    stop("Could not find any URLs matching input parameters")
-  }
+  seasons_urls <- unique(seasons_urls[["seasons_urls"]])
+
+  stopifnot("Could not find any URLs matching input parameters" = length(seasons_urls) > 0)
 
   urls <- tidyr::crossing(
     "league_url" = seasons_urls,

--- a/man/fb_league_stats.Rd
+++ b/man/fb_league_stats.Rd
@@ -68,6 +68,17 @@ fb_season_team_stats(
   stat_type = "shooting",
   team_or_player = "player"
 )
+## Non-domestic league
+##   Note that this is more likely to fail due to the volume of players
+fb_league_stats(
+  country = NA_character_,
+  gender = "M",
+  season_end_year = 2023,
+  tier = NA_character_,
+  non_dom_league_url = "https://fbref.com/en/comps/8/history/Champions-League-Seasons",
+  stat_type = "standard",
+  team_or_player = "player"
+)
 })
 }
 }

--- a/tests/testthat/test-fbref.R
+++ b/tests/testthat/test-fbref.R
@@ -393,6 +393,19 @@ test_that("fb_league_stats() for players works", {
   expect_gt(nrow(multi_season_player_misc), 0)
   expect_setequal(colnames(multi_season_player_misc), expected_player_misc_cols)
   expect_equal(length(unique(multi_season_player_misc$url)), 2)
+
+  ## Non-domestic league
+  # ucl_player_stats_23 <- fb_league_stats(
+  #   country = NA_character_,
+  #   gender = "M",
+  #   season_end_year = 2023,
+  #   tier = NA_character_,
+  #   non_dom_league_url = "https://fbref.com/en/comps/8/history/Champions-League-Seasons",
+  #   stat_type = "standard",
+  #   team_or_player = "player"
+  # )
+  # expect_gt(nrow(ucl_player_stats_23), 0)
+  # expect_setequal(colnames(ucl_player_stats_23), ucl_player_stats_23)
 })
 
 test_that("fb_league_stats() for teams works", {


### PR DESCRIPTION
Regarding issue #319, the specific bug reported was probably due to promises not working properly. That said, for what I can see the non_dom_league_url param is not actually used inside the fb_league_stats() function. I've implemented the same approach as fb_match_results() to try and fix that.