### PR TITLE
Fix duplicate player hrefs in FBref functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.4.0007
+Version: 0.6.4.0008
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `fb_league_stats()` failing for `playing_time`. (0.6.4.0001) [#314](https://github.com/JaseZiv/worldfootballR/issues/314)
 * `fb_advanced_match_stats()` throwing errors when there were no stat tables available for matches (0.6.4.0002) [#315](https://github.com/JaseZiv/worldfootballR/issues/315)
 * `fb_player_match_logs()` failing for players who have played on multiple teams/leagues in the same season (0.6.4.0006) [#327](https://github.com/JaseZiv/worldfootballR/issues/327)
+* `fb_league_stats(team_or_player = "player")` returning duplicate player hrefs (0.6.4.0008) [#331](https://github.com/JaseZiv/worldfootballR/issues/331)
 
 ### Improvements
 * `fb_player_season_stats()` now includes the ability to get a player's national team stats [https://github.com/JaseZiv/worldfootballR/pull/310/files] (0.6.4.0002)

--- a/R/fb_league_stats.R
+++ b/R/fb_league_stats.R
@@ -48,7 +48,7 @@
       return(tibble::tibble())
     }
     renamed_table <- .rename_fb_cols(tables[[3]])
-    renamed_table[renamed_table$Rk != "Rk", ]
+    renamed_table <- renamed_table[renamed_table$Rk != "Rk", ]
     renamed_table <- .add_player_href(
       renamed_table,
       parent_element = elements[[3]],

--- a/R/get_advanced_match_stats.R
+++ b/R/get_advanced_match_stats.R
@@ -3,13 +3,10 @@
 #' @importFrom stats setNames
 .add_player_href <- function(df, parent_element, player_xpath) {
   player_elements <- xml2::xml_find_all(parent_element, player_xpath)
-  players <- stats::setNames(
-    xml2::xml_attr(player_elements, "href"),
-    xml2::xml_text(player_elements)
-  )
+  player_hrefs <- xml2::xml_attr(player_elements, "href")
   res <- dplyr::mutate(
     df,
-    "Player_Href" = players[df$Player],
+    "Player_Href" = player_hrefs,
     .after = "Player"
   )
   return(res)

--- a/R/get_advanced_match_stats.R
+++ b/R/get_advanced_match_stats.R
@@ -4,9 +4,11 @@
 .add_player_href <- function(df, parent_element, player_xpath) {
   player_elements <- xml2::xml_find_all(parent_element, player_xpath)
   player_hrefs <- xml2::xml_attr(player_elements, "href")
+  ## we need to apd for fb_advanced_stats, where there is a total row at the bottom
+  n_diff <- nrow(df) - length(player_hrefs)
   res <- dplyr::mutate(
     df,
-    "Player_Href" = player_hrefs,
+    "Player_Href" = c(player_hrefs, rep(NA_character_, n_diff)),
     .after = "Player"
   )
   return(res)


### PR DESCRIPTION
It was possible for FBref functions that returned `Player_Href` (added with #328) to return "bad" links when there are different players with the same exact name. This is fixed by simply joining the hrefs back to the rest of the dataframe rather than doing a lookup by name. The new approach may encounter an error if a player does not have an FBref page for some reason, although I've never actually seen that before.

Fixes #327.