### PR TITLE
Fix `fb_player_stats()` bug with current seasons

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.4.0008
+Version: 0.6.4.0009
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * `fb_advanced_match_stats()` throwing errors when there were no stat tables available for matches (0.6.4.0002) [#315](https://github.com/JaseZiv/worldfootballR/issues/315)
 * `fb_player_match_logs()` failing for players who have played on multiple teams/leagues in the same season (0.6.4.0006) [#327](https://github.com/JaseZiv/worldfootballR/issues/327)
 * `fb_league_stats(team_or_player = "player")` returning duplicate player hrefs (0.6.4.0008) [#331](https://github.com/JaseZiv/worldfootballR/issues/331)
+worldfootballR/issues/327)
+* `fb_league_stats(team_or_player = "player")` returning wrong season's data for Australian league (0.6.4.0009) [#333](https://github.com/JaseZiv/worldfootballR/issues/333)
 
 ### Improvements
 * `fb_player_season_stats()` now includes the ability to get a player's national team stats [https://github.com/JaseZiv/worldfootballR/pull/310/files] (0.6.4.0002)


### PR DESCRIPTION
The `fb_player_stats()` function seemed to be pulling the wrong season URL for the Australian men's 1st tier league, for the 2023 season. This is because our season URL CSV is still marking the 2022-23 season as the current season.

While we could just try to make our processes around indicating the prompt season in the CSV more robust, an alternative, possibly less fragile approach is to construct the season URL from the competition URL and the season name (using the same CSV's data). We can always rely on the "full" season URL being correct, even with a competition's current season.

For example, the player playing time URL for the aforementioned league can be referred to both as `https://fbref.com/en/comps/65/2023-2024/playingtime/2023-2024-A-League-Men-Stats` or just `https://fbref.com/en/comps/65/playingtime/Premier-League-Stats`, if the current season is 2023-2024. This PR changes the logic such that we always use the former style rather than the latter, since the latter can be prone to stale in our CSV.

## Appendix

Fixes #333.

```r
res <- worldfootballR::fb_league_stats(
  country = "AUS",
  gender = "M",
  season_end_year = 2023,
  tier = "1st",
  non_dom_league_url = NA,
  stat_type = "playing_time",
  team_or_player = "player",
  time_pause = 4
)
dplyr::glimpse(res)
#> Rows: 350
#> Columns: 27
#> $ Rk                          <int> 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,…
#> $ Player                      <chr> "Matt Acton", "Eli Adams", "Moonib Adus", …
#> $ Player_Href                 <chr> "/en/players/7dccb8b7/Matt-Acton", "/en/pl…
#> $ Nation                      <chr> "au AUS", "au AUS", "au AUS", "au AUS", "a…
#> $ Pos                         <chr> "GK", "FW", "MF", "MF,FW", "MF", "DF", "MF…
#> $ Squad                       <chr> "Melb Victory", "Melb Victory", "Newcastle…
#> $ Age                         <int> 30, 20, 19, 22, 18, 31, 32, 29, 28, 21, 21…
#> $ Born                        <int> 1992, 2002, 2003, 2000, 2003, 1990, 1989, …
#> $ `MP_Playing Time`           <int> 7, 5, 1, 22, 20, 24, 24, 19, 5, 12, 11, 15…
#> $ `Min_Playing Time`          <dbl> 630, 67, 4, 859, 778, 2160, 1923, 1535, 20…
#> $ `Mn_per_MP_Playing Time`    <int> 90, 13, 4, 39, 39, 90, 80, 81, 41, 61, 54,…
#> $ `Min_percent_Playing Time`  <dbl> 26.9, 2.9, 0.2, 36.7, 33.2, 92.3, 82.2, 65…
#> $ `Mins_Per_90_Playing Time`  <dbl> 7.0, 0.7, 0.0, 9.5, 8.6, 24.0, 21.4, 17.1,…
#> $ Starts_Starts               <int> 7, 1, 0, 9, 7, 24, 24, 19, 2, 7, 6, 11, 15…
#> $ Mn_per_Start_Starts         <int> 90, 45, NA, 66, 69, 90, 80, 81, 75, 86, 81…
#> $ Compl_Starts                <int> 7, 0, 0, 2, 1, 24, 10, 7, 1, 6, 3, 3, 1, 2…
#> $ Subs_Subs                   <int> 0, 4, 1, 13, 13, 0, 0, 0, 3, 5, 5, 4, 9, 7…
#> $ Mn_per_Sub_Subs             <int> NA, 6, 4, 20, 23, NA, NA, NA, 19, 25, 20, …
#> $ unSub_Subs                  <int> 17, 2, 0, 3, 3, 0, 2, 0, 6, 2, 0, 2, 2, 0,…
#> $ `PPM_Team Success`          <dbl> 0.57, 1.20, 0.00, 1.23, 1.68, 1.13, 1.48, …
#> $ `onG_Team Success`          <int> 8, 0, 0, 7, 16, 24, 35, 25, 4, 20, 6, 10, …
#> $ `onGA_Team Success`         <int> 12, 1, 0, 11, 14, 31, 20, 29, 3, 13, 10, 1…
#> $ `Plus_Minus_Team Success`   <int> -4, -1, 0, -4, 2, -7, 15, -4, 1, 7, -4, -4…
#> $ `Plus_Minus90_Team Success` <dbl> -0.57, -1.34, 0.00, -0.42, 0.23, -0.29, 0.…
#> $ `On_minus_Off_Team Success` <dbl> -0.52, -1.18, 0.58, -0.24, -0.06, -0.29, 0…
#> $ Matches                     <chr> "Matches", "Matches", "Matches", "Matches"…
#> $ url                         <chr> "https://fbref.com/en/comps/65/2022-2023/p…
```
