### PR TITLE
Fix bug with retrieving opponent team stats with `fb_league_stats`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.5
+Version: 0.6.5.0001
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # worldfootballR (development version)
 
+### Bugs
+
+* `fb_league_stats()` not returning `opponent` table. (0.6.5.0001) [#355](https://github.com/JaseZiv/worldfootballR/issues/355)
+
 ***
 
 # worldfootballR 0.6.5

--- a/R/fb_league_stats.R
+++ b/R/fb_league_stats.R
@@ -18,7 +18,7 @@
     }
 
     purrr::map_dfr(
-      seq_along(n_tables),
+      1:n_tables,
       ~{
         tables[[.x]] %>%
           .rename_fb_cols() %>%


### PR DESCRIPTION
Fixes #355.

Code below returns 36 rows instead of 18, which it was incorrectly doing before.

```r
library(worldfootballR)
packageVersion('worldfootballR')
#> [1] '0.6.5.1'
data <- fb_league_stats(
  country = c("POR"),
  gender = "M",
  season_end_year = 2024,
  stat_type = "shooting",
  team_or_player = "team"
)
dplyr::glimpse(data)
#> Rows: 36
#> Columns: 22
#> $ Team_or_Opponent         <chr> "team", "team", "team", "team", "team", "team…
#> $ Squad                    <chr> "Arouca", "Benfica", "Boavista", "Braga", "Ca…
#> $ Num_Players              <int> 25, 28, 23, 23, 26, 28, 25, 27, 23, 23, 27, 2…
#> $ Mins_Per_90              <dbl> 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 1…
#> $ Gls_Standard             <int> 22, 34, 24, 39, 18, 18, 31, 16, 17, 23, 27, 2…
#> $ Sh_Standard              <int> 230, 301, 176, 289, 173, 213, 212, 172, 221, …
#> $ SoT_Standard             <int> 75, 114, 62, 101, 55, 68, 77, 46, 57, 68, 68,…
#> $ SoT_percent_Standard     <dbl> 32.6, 37.9, 35.2, 34.9, 31.8, 31.9, 36.3, 26.…
#> $ Sh_per_90_Standard       <dbl> 13.53, 17.71, 10.35, 17.00, 10.18, 12.53, 12.…
#> $ SoT_per_90_Standard      <dbl> 4.41, 6.71, 3.65, 5.94, 3.24, 4.00, 4.53, 2.7…
#> $ G_per_Sh_Standard        <dbl> 0.10, 0.11, 0.13, 0.12, 0.09, 0.07, 0.14, 0.0…
#> $ G_per_SoT_Standard       <dbl> 0.29, 0.28, 0.35, 0.36, 0.27, 0.22, 0.39, 0.3…
#> $ Dist_Standard            <dbl> 19.0, 16.7, 18.0, 17.0, 20.0, 19.1, 18.6, 17.…
#> $ FK_Standard              <int> 10, 11, 5, 11, 1, 11, 16, 10, 12, 6, 5, 7, 8,…
#> $ PK_Standard              <int> 0, 2, 2, 3, 3, 3, 1, 1, 1, 3, 5, 1, 3, 3, 3, …
#> $ PKatt_Standard           <int> 2, 2, 2, 3, 4, 3, 1, 1, 2, 4, 6, 1, 4, 5, 3, …
#> $ xG_Expected              <dbl> 22.5, 38.4, 19.5, 34.6, 14.2, 18.5, 21.6, 19.…
#> $ npxG_Expected            <dbl> 21.0, 36.8, 18.0, 32.7, 11.1, 16.1, 20.8, 18.…
#> $ npxG_per_Sh_Expected     <dbl> 0.09, 0.13, 0.11, 0.12, 0.06, 0.08, 0.10, 0.1…
#> $ G_minus_xG_Expected      <dbl> -0.5, -4.4, 4.5, 4.4, 3.8, -0.5, 9.4, -3.4, 1…
#> $ `np:G_minus_xG_Expected` <dbl> 1.0, -4.8, 4.0, 3.3, 3.9, -1.1, 9.2, -3.6, 2.…
#> $ url                      <chr> "https://fbref.com/en/comps/32/2023-2024/shoo…
```