### PR TITLE
always choose the first table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.5.0007
+Version: 0.6.5.0008
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * `tm_player_bio()` not returning values in the `player_valuation`, `max_player_valuation` and `max_player_valuation_date` fields. Unfortunately, `max_player_valuation` and `max_player_valuation_date` fields are no able to be scraped at this release (0.6.5.0002) [#357](https://github.com/JaseZiv/worldfootballR/issues/357)
 * `fb_league_stats()` not returning `player` table when hidden on page load. (0.6.5.0003) [#351](https://github.com/JaseZiv/worldfootballR/issues/351)
 * Fix parameter mis-sepcification in fbref vignette. (0.6.5.0005) [#385](https://github.com/JaseZiv/worldfootballR/issues/385)
-* `fb_season_team_stats()` failing due to change in FBRef table name. (0.6.5.0007) [#395](https://github.com/JaseZiv/worldfootballR/issues/389)
+* `fb_season_team_stats()` failing due to change in FBRef table name. (0.6.5.0007, 0.6.5.0008) [#395](https://github.com/JaseZiv/worldfootballR/issues/389)
 
 ### Breaking Changes
 

--- a/R/get_season_team_stats.R
+++ b/R/get_season_team_stats.R
@@ -73,13 +73,7 @@ fb_season_team_stats <- function(country, gender, season_end_year, tier, stat_ty
     # have included this to differentiate between how different leagues handle ladders/tables
     league_tables <- season_stats_page %>% rvest::html_nodes("#content .table_wrapper") %>% rvest::html_elements("h2") %>% rvest::html_text()
 
-    # we either want to detect the presence of League Table or Regular season and get the index of that to be able to extractg the table we want
-    if(length(grep(competition_name, league_tables)) > 0) {
-      league_tables_idx <- grep(competition_name, league_tables)
-    } else {
-      league_tables_idx <- grep("^Regular season", league_tables)
-    }
-
+    league_tables_idx <- 1
 
     league_standings <- season_stats_page %>% rvest::html_nodes("table")
 


### PR DESCRIPTION
Fixes #389. Prior PR assumed that `competition_name` in `all_seasons.csv` would match what is shown on the FBRef page, but that doesn't always turn out to be the case, e.g. Bundesliga. I've made a change to remove string searching, and instead assume the points table is always the first on the page. I'm 99% sure that this should work for all leagues, although I haven't tested it comprehensively.

Confirmed that this works.

```r
fb_season_team_stats(
  ## USA is an odd case since it has conferences, so its table shows "Regular Season"
  country = c("ENG", "ESP", "GER", "ITA", "FRA", "USA"),
  gender = "M",
  season_end_year = c(2013:2024),
  tier = "1st",
  stat_type = "league_table",
  time_pause = 5
)
```