### PR TITLE
bugfix: `tm_team_transfer()` returns both Arrivals and Departures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: worldfootballR
 Title: Extract and Clean World Football (Soccer) Data
-Version: 0.6.7.0003
+Version: 0.6.7.0004
 Authors@R: c(
     person("Jason", "Zivkovic", , "jaseziv83@gmail.com", role = c("aut", "cre", "cph")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Bugs
 
+* `tm_team_transfers()` correctly returns both Arrivals and Departures. (0.6.7.0004) ([#433](https://github.com/JaseZiv/worldfootballR/issues/433))
+
 ### Breaking Changes
 
 ### Improvements


### PR DESCRIPTION
Fixes #433.

Issue was being caused by empty section for `Transfermarkt Videos` h2 header, so a subsequent call to `html_nodes()` (renamed to `html_elements()` in newer versions for `{rvest}`) was discarding one of the h2 headers, which resulted in incorrect indexing when plucking out the `Departures` section. Using `html_element()` instead of `html_elements()` solves the problem. Per `{rvest}` docs:

```
html_element() returns a nodeset the same length as the input.
html_elements() flattens the output so there's no direct way to map the output to the input.
```